### PR TITLE
bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrep"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Dmytro Milinevskyi <dmilinevskyi@gmail.com>"]
 description = "Toy grep that honors .gitignore"
 license = "Unlicense"


### PR DESCRIPTION
Implemented `-c` since `1.6.0`