### PR TITLE
Run clippy and tests on pull requests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,7 +1,9 @@
 # From https://github.com/marketplace/actions/rust-clippy-check
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 name: Clippy check
 jobs:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,5 +1,8 @@
 # From https://github.com/marketplace/actions/rust-clippy-check
-on: push
+on:
+  push:
+  pull_request:
+
 name: Clippy check
 jobs:
   clippy_check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 name: Test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+  pull_request:
+
+name: Test
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: cargo test


### PR DESCRIPTION
## Summary

- run the existing clippy workflow on both `push` and `pull_request`
- add a dedicated `cargo test` workflow for both `push` and `pull_request`

## Testing

- not run locally for workflow execution
