### PR TITLE
Increase test coverage for grep, walker, and utility modules

### DIFF
--- a/src/utils/filters.rs
+++ b/src/utils/filters.rs
@@ -28,3 +28,27 @@ impl Filters {
         self.patterns.matches(path, false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_prefixed_glob_filters() {
+        let filters = Filters::new(&["*.rs".to_string(), "src/*.toml".to_string()]).unwrap();
+
+        assert!(filters.matches("/tmp/project/src/main.rs"));
+        assert!(filters.matches("/tmp/project/src/Cargo.toml"));
+        assert!(!filters.matches("/tmp/project/src/main.py"));
+        assert!(!filters.matches("/tmp/project/Cargo.toml"));
+    }
+
+    #[test]
+    fn preserves_double_star_prefixes() {
+        let filters = Filters::new(&["**/README.md".to_string()]).unwrap();
+
+        assert!(filters.matches("/tmp/project/README.md"));
+        assert!(filters.matches("/tmp/project/docs/README.md"));
+        assert!(!filters.matches("/tmp/project/docs/README.txt"));
+    }
+}

--- a/src/utils/grep.rs
+++ b/src/utils/grep.rs
@@ -196,3 +196,316 @@ pub fn grep_count() -> Grep {
         },
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use streaming_iterator::StreamingIterator;
+
+    use super::*;
+    use crate::utils::display::{DisplayTerminal, Format, PathFormat};
+    use crate::utils::lines::LineIterator;
+    use crate::utils::writer::Writer;
+
+    #[derive(Clone)]
+    struct TestWriter {
+        writes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                writes: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn lines(&self) -> Vec<String> {
+            self.writes.lock().unwrap().clone()
+        }
+    }
+
+    impl Writer for TestWriter {
+        fn write(&self, content: &str) {
+            self.writes.lock().unwrap().push(content.to_owned());
+        }
+    }
+
+    struct TestReader {
+        path: PathBuf,
+        content: String,
+        lines: Vec<String>,
+        map_supported: bool,
+        lines_called: Arc<AtomicUsize>,
+    }
+
+    impl TestReader {
+        fn new(path: &str, lines: &[&str], map_supported: bool) -> Self {
+            Self {
+                path: PathBuf::from(path),
+                content: lines.join("\n"),
+                lines: lines.iter().map(|line| (*line).to_owned()).collect(),
+                map_supported,
+                lines_called: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn lines_called(&self) -> usize {
+            self.lines_called.load(Ordering::Relaxed)
+        }
+    }
+
+    impl LinesReader for TestReader {
+        fn map(&self) -> anyhow::Result<&str> {
+            if self.map_supported {
+                Ok(&self.content)
+            } else {
+                anyhow::bail!("not supported")
+            }
+        }
+
+        fn lines(&self) -> anyhow::Result<Box<LineIterator>> {
+            self.lines_called.fetch_add(1, Ordering::Relaxed);
+            Ok(Box::new(TestLineIterator::new(self.lines.clone())))
+        }
+
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+
+    struct TestLineIterator {
+        lines: Vec<String>,
+        pos: usize,
+    }
+
+    impl TestLineIterator {
+        fn new(lines: Vec<String>) -> Self {
+            Self { lines, pos: 0 }
+        }
+    }
+
+    impl StreamingIterator for TestLineIterator {
+        type Item = str;
+
+        fn advance(&mut self) {
+            if self.pos < self.lines.len() {
+                self.pos += 1;
+            }
+        }
+
+        fn get(&self) -> Option<&Self::Item> {
+            self.lines.get(self.pos).map(String::as_str)
+        }
+
+        fn next(&mut self) -> Option<&Self::Item> {
+            let line = self.lines.get(self.pos).map(String::as_str);
+            if line.is_some() {
+                self.pos += 1;
+            }
+            line
+        }
+    }
+
+    fn matcher(needle: &'static str) -> Matcher {
+        Arc::new(Box::new(move |line: &str, options| match options {
+            MatcherOptions::Fuzzy => line.find(needle).map(|_| vec![Match::new(0, needle.len())]),
+            MatcherOptions::Exact(max) => {
+                let mut matches = Vec::new();
+                let mut start = 0;
+                while let Some(offset) = line[start..].find(needle) {
+                    let start_offset = start + offset;
+                    matches.push(Match::new(start_offset, start_offset + needle.len()));
+                    start = start_offset + needle.len();
+                    if matches.len() == max {
+                        break;
+                    }
+                }
+                if matches.is_empty() {
+                    None
+                } else {
+                    Some(matches)
+                }
+            }
+        }))
+    }
+
+    fn display(format: Format, writer: Arc<dyn Writer>) -> Arc<dyn Display> {
+        let path_format: PathFormat = Arc::new(Box::new(|path: &Path| {
+            path.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        }));
+        Arc::new(DisplayTerminal::new(120, format, path_format, writer))
+    }
+
+    #[test]
+    fn grep_outputs_all_matching_lines() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new(
+            "sample.txt",
+            &["alpha", "beta needle", "needle gamma"],
+            true,
+        ));
+
+        grep()(
+            reader,
+            matcher("needle"),
+            display(
+                Format::Rich {
+                    colour: false,
+                    match_only: false,
+                    no_path: false,
+                    no_lno: false,
+                },
+                Arc::new(writer.clone()),
+            ),
+        );
+
+        assert_eq!(
+            vec!["sample.txt:2: beta needle", "sample.txt:3: needle gamma"],
+            writer.lines()
+        );
+    }
+
+    #[test]
+    fn grep_skips_line_iteration_when_fuzzy_match_fails() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new("sample.txt", &["alpha", "beta"], true));
+
+        grep()(
+            reader.clone(),
+            matcher("needle"),
+            display(
+                Format::Rich {
+                    colour: false,
+                    match_only: false,
+                    no_path: false,
+                    no_lno: false,
+                },
+                Arc::new(writer.clone()),
+            ),
+        );
+
+        assert_eq!(0, reader.lines_called());
+        assert!(writer.lines().is_empty());
+    }
+
+    #[test]
+    fn grep_with_context_prints_context_and_separator_between_groups() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new(
+            "sample.txt",
+            &[
+                "alpha",
+                "needle one",
+                "gamma",
+                "delta",
+                "epsilon",
+                "needle two",
+                "zeta",
+            ],
+            false,
+        ));
+
+        grep_with_context(1, 1)(
+            reader,
+            matcher("needle"),
+            display(
+                Format::Rich {
+                    colour: false,
+                    match_only: false,
+                    no_path: false,
+                    no_lno: false,
+                },
+                Arc::new(writer.clone()),
+            ),
+        );
+
+        assert_eq!(
+            vec![
+                "sample.txt-1- alpha",
+                "sample.txt:2: needle one",
+                "sample.txt-3- gamma",
+                "..",
+                "sample.txt-5- epsilon",
+                "sample.txt:6: needle two",
+                "sample.txt-7- zeta",
+            ],
+            writer.lines()
+        );
+    }
+
+    #[test]
+    fn grep_matches_once_stops_after_first_match() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new(
+            "sample.txt",
+            &["needle one", "needle two"],
+            false,
+        ));
+
+        grep_matches_once()(
+            reader,
+            matcher("needle"),
+            display(
+                Format::Rich {
+                    colour: false,
+                    match_only: false,
+                    no_path: false,
+                    no_lno: false,
+                },
+                Arc::new(writer.clone()),
+            ),
+        );
+
+        assert_eq!(vec!["sample.txt:1: needle one"], writer.lines());
+    }
+
+    #[test]
+    fn grep_matches_all_lines_prints_only_matching_path() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new(
+            "sample.txt",
+            &["needle one", "needle two"],
+            false,
+        ));
+
+        grep_matches_all_lines()(
+            reader,
+            matcher("needle"),
+            display(Format::PathOnly { colour: false }, Arc::new(writer.clone())),
+        );
+
+        assert_eq!(vec!["sample.txt"], writer.lines());
+    }
+
+    #[test]
+    fn grep_count_prints_number_of_matching_lines() {
+        let writer = TestWriter::new();
+        let reader = Arc::new(TestReader::new(
+            "sample.txt",
+            &["needle one", "other", "needle two"],
+            false,
+        ));
+
+        grep_count()(
+            reader,
+            matcher("needle"),
+            display(
+                Format::Rich {
+                    colour: false,
+                    match_only: false,
+                    no_path: false,
+                    no_lno: false,
+                },
+                Arc::new(writer.clone()),
+            ),
+        );
+
+        assert_eq!(vec!["sample.txt:0: 2"], writer.lines());
+    }
+}

--- a/src/utils/lines.rs
+++ b/src/utils/lines.rs
@@ -129,3 +129,35 @@ impl StreamingIterator for Zero {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use streaming_iterator::StreamingIterator;
+
+    use super::*;
+
+    #[test]
+    fn lines_trim_lf_and_crlf_endings() {
+        let mut lines = Lines::new(
+            Cursor::new(b"alpha\nbeta\r\ngamma".to_vec()),
+            PathBuf::from("input.txt"),
+        );
+
+        assert_eq!(Some("alpha"), lines.next());
+        assert_eq!(Some("beta"), lines.next());
+        assert_eq!(Some("gamma"), lines.next());
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn zero_reader_maps_to_empty_and_has_no_lines() {
+        let zero = Zero::new(PathBuf::from("empty.txt"));
+
+        assert_eq!("", LinesReader::map(&zero).unwrap());
+
+        let mut lines = zero.lines().unwrap();
+        assert_eq!(None, lines.next());
+    }
+}

--- a/src/utils/mapped.rs
+++ b/src/utils/mapped.rs
@@ -89,10 +89,7 @@ impl StreamingIterator for MappedLines {
             None => mmap.len(),
         };
         self.pos = self.line.end + 1;
-        if self.pos < self.mapped.mmap.len() && mmap[self.pos] == b'\r' {
-            self.pos += 1;
-        }
-        if (1..mmap.len()).contains(&self.line.end) && mmap[self.line.end] == b'\r' {
+        if self.line.end > self.line.start && mmap[self.line.end - 1] == b'\r' {
             self.line.end -= 1;
         }
     }
@@ -121,5 +118,74 @@ impl StreamingIterator for MappedLines {
                 Some(&self.buf)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    struct TempFile {
+        path: PathBuf,
+    }
+
+    impl TempFile {
+        fn new(contents: &[u8]) -> Self {
+            let mut path = std::env::temp_dir();
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            path.push(format!("tgrep-mapped-test-{}", unique));
+            fs::write(&path, contents).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    #[test]
+    fn mapped_reader_returns_lines() {
+        let file = TempFile::new(b"alpha\nbeta\ngamma");
+        let mapped = Mapped::new(file.path(), 16).unwrap();
+        let mut lines = mapped.lines().unwrap();
+
+        assert_eq!(Some("alpha"), lines.next());
+        assert_eq!(Some("beta"), lines.next());
+        assert_eq!(Some("gamma"), lines.next());
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn mapped_reader_trims_cr_before_lf() {
+        let file = TempFile::new(b"alpha\r\nbeta\r\n");
+        let mapped = Mapped::new(file.path(), 13).unwrap();
+        let mut lines = mapped.lines().unwrap();
+
+        assert_eq!(Some("alpha"), lines.next());
+        assert_eq!(Some("beta"), lines.next());
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn mapped_reader_falls_back_for_invalid_utf8() {
+        let file = TempFile::new(b"ok\nf\x80o\n");
+        let mapped = Mapped::new(file.path(), 7).unwrap();
+        let mut lines = mapped.lines().unwrap();
+
+        assert_eq!(Some("ok"), lines.next());
+        assert_eq!(Some("f\u{80}o"), lines.next());
+        assert_eq!(None, lines.next());
     }
 }

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -370,6 +370,8 @@ impl Walker {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -433,6 +435,11 @@ mod tests {
 
         fn mkdir(&self, relative: &str) {
             fs::create_dir_all(self.path.join(relative)).unwrap();
+        }
+
+        #[cfg(unix)]
+        fn symlink_dir(&self, target: &Path, link: &str) {
+            symlink(target, self.path.join(link)).unwrap();
         }
     }
 
@@ -547,5 +554,54 @@ mod tests {
         walker.walk(temp.path());
 
         assert_eq!(vec!["visible.txt"], writer.lines());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_skips_symlinks_when_configured() {
+        let temp = TempDir::new();
+        let external = TempDir::new();
+        external.write("linked.txt", b"external\n");
+        temp.symlink_dir(external.path(), "external-link");
+
+        let writer = TestWriter::new();
+        let walker = WalkerBuilder::new(
+            grep_recorder(),
+            matcher(),
+            display(Arc::new(writer.clone())),
+        )
+        .ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .force_ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .file_filters(Filters::new(&["*".to_string()]).unwrap())
+        .ignore_symlinks(true)
+        .build();
+
+        walker.walk(temp.path());
+
+        assert!(writer.lines().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_follows_external_directory_symlinks() {
+        let temp = TempDir::new();
+        let external = TempDir::new();
+        external.write("linked.txt", b"external\n");
+        temp.symlink_dir(external.path(), "external-link");
+
+        let writer = TestWriter::new();
+        let walker = WalkerBuilder::new(
+            grep_recorder(),
+            matcher(),
+            display(Arc::new(writer.clone())),
+        )
+        .ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .force_ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .file_filters(Filters::new(&["*".to_string()]).unwrap())
+        .build();
+
+        walker.walk(temp.path());
+
+        assert_eq!(vec!["linked.txt"], writer.lines());
     }
 }

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -366,3 +366,186 @@ impl Walker {
         self.walk_with_parents(path, None, &[]);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::utils::display::DisplayTerminal;
+    use crate::utils::display::{Format, PathFormat};
+    use crate::utils::matcher::Match;
+    use crate::utils::writer::Writer;
+
+    #[derive(Clone)]
+    struct TestWriter {
+        writes: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                writes: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn lines(&self) -> Vec<String> {
+            self.writes.lock().unwrap().clone()
+        }
+    }
+
+    impl Writer for TestWriter {
+        fn write(&self, content: &str) {
+            self.writes.lock().unwrap().push(content.to_owned());
+        }
+    }
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let mut path = std::env::temp_dir();
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            path.push(format!("tgrep-walker-test-{}", unique));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn write(&self, relative: &str, contents: &[u8]) {
+            let path = self.path.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, contents).unwrap();
+        }
+
+        fn mkdir(&self, relative: &str) {
+            fs::create_dir_all(self.path.join(relative)).unwrap();
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn matcher() -> Matcher {
+        Arc::new(Box::new(|_, _| Some(vec![Match::new(0, 0)])))
+    }
+
+    fn display(writer: Arc<dyn Writer>) -> Arc<dyn Display> {
+        let path_format: PathFormat = Arc::new(Box::new(|path: &Path| {
+            path.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        }));
+        Arc::new(DisplayTerminal::new(
+            120,
+            Format::PathOnly { colour: false },
+            path_format,
+            writer,
+        ))
+    }
+
+    fn grep_recorder() -> Grep {
+        Arc::new(Box::new(|reader, _, display| {
+            display.display(reader.path(), None);
+        }))
+    }
+
+    #[test]
+    fn finds_parent_gitignore_until_git_dir() {
+        let temp = TempDir::new();
+        temp.mkdir(".git");
+        temp.write(".gitignore", b"root-ignored.txt\n");
+        temp.mkdir("nested/deep");
+        temp.write("nested/.gitignore", b"nested-ignored.txt\n");
+
+        let patterns = Walker::find_ignore_patterns_in_parents(&temp.path().join("nested/deep"))
+            .expect("expected parent ignore patterns");
+
+        let root_ignored = temp.path().join("root-ignored.txt");
+        let nested_ignored = temp.path().join("nested/nested-ignored.txt");
+        let outside = temp.path().join("nested/deep/visible.txt");
+
+        assert!(patterns.is_excluded(root_ignored.to_str().unwrap(), false));
+        assert!(patterns.is_excluded(nested_ignored.to_str().unwrap(), false));
+        assert!(!patterns.is_excluded(outside.to_str().unwrap(), false));
+    }
+
+    #[test]
+    fn does_not_search_beyond_repository_root_for_parent_gitignores() {
+        let outer = TempDir::new();
+        outer.write(".gitignore", b"outside.txt\n");
+        outer.mkdir("repo/.git");
+        outer.mkdir("repo/nested");
+
+        let patterns = Walker::find_ignore_patterns_in_parents(&outer.path().join("repo/nested"));
+
+        let outside = outer.path().join("outside.txt");
+        assert!(patterns.is_none() || !patterns.unwrap().is_excluded(outside.to_str().unwrap(), false));
+    }
+
+    #[test]
+    fn walk_honors_gitignore_and_file_filters() {
+        let temp = TempDir::new();
+        temp.write(".gitignore", b"ignored.txt\n");
+        temp.write("visible.rs", b"fn main() {}\n");
+        temp.write("ignored.txt", b"secret\n");
+        temp.write("notes.md", b"# notes\n");
+
+        let writer = TestWriter::new();
+        let walker = WalkerBuilder::new(
+            grep_recorder(),
+            matcher(),
+            display(Arc::new(writer.clone())),
+        )
+        .ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .force_ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .file_filters(Filters::new(&["*.rs".to_string()]).unwrap())
+        .build();
+
+        walker.walk(temp.path());
+
+        assert_eq!(vec!["visible.rs"], writer.lines());
+    }
+
+    #[test]
+    fn force_ignore_patterns_override_walk_results() {
+        let temp = TempDir::new();
+        temp.write("visible.txt", b"ok\n");
+        temp.write("forced.txt", b"skip\n");
+
+        let writer = TestWriter::new();
+        let walker = WalkerBuilder::new(
+            grep_recorder(),
+            matcher(),
+            display(Arc::new(writer.clone())),
+        )
+        .ignore_patterns(Patterns::new(temp.path().to_str().unwrap(), &[]))
+        .force_ignore_patterns(Patterns::new(
+            temp.path().to_str().unwrap(),
+            &["forced.txt".to_string()],
+        ))
+        .file_filters(Filters::new(&["*".to_string()]).unwrap())
+        .build();
+
+        walker.walk(temp.path());
+
+        assert_eq!(vec!["visible.txt"], writer.lines());
+    }
+}

--- a/src/utils/writer.rs
+++ b/src/utils/writer.rs
@@ -62,3 +62,48 @@ impl Writer for BufferedWriter {
         lines.push(content.to_owned());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestWriter {
+        writes: Arc<Mutex<RefCell<Vec<String>>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                writes: Arc::new(Mutex::new(RefCell::new(Vec::new()))),
+            }
+        }
+
+        fn lines(&self) -> Vec<String> {
+            self.writes.lock().unwrap().borrow().clone()
+        }
+    }
+
+    impl Writer for TestWriter {
+        fn write(&self, content: &str) {
+            self.writes.lock().unwrap().borrow_mut().push(content.to_owned());
+        }
+    }
+
+    #[test]
+    fn buffered_writer_tracks_presence_and_flushes_in_order() {
+        let buffered = BufferedWriter::new();
+        let test_writer = Arc::new(TestWriter::new());
+        let writer: Arc<dyn Writer> = test_writer.clone();
+
+        assert!(!buffered.has_some());
+
+        buffered.write("first");
+        buffered.write("second");
+
+        assert!(buffered.has_some());
+        buffered.flush(&writer);
+
+        assert_eq!(vec!["first", "second"], test_writer.lines());
+    }
+}


### PR DESCRIPTION
## Summary

- add focused grep behavior tests
- add walker traversal, ignore, and symlink tests
- add reader and utility tests for lines, mmap, filters, and buffered writer
- fix CRLF trimming in the mmap reader uncovered by the new tests

## Testing

- `cargo test`
- `cargo clippy --all-targets --all-features`
