### PR TITLE
Reference: performance investigation checkpoint

### DIFF
--- a/PERF_PLAN.md
+++ b/PERF_PLAN.md
@@ -1,0 +1,249 @@
+# Performance Investigation Plan
+
+## Goal
+
+Reduce `tgrep` overhead on large file trees without regressing correctness or deterministic output ordering.
+
+The reference workload used so far is a no-match search over a large source tree with:
+
+```bash
+tgrep fooxxxyyy <large-tree>
+```
+
+This is useful because it exposes traversal and per-file setup costs without conflating them with output volume.
+
+## Current State
+
+The branch already contains the low-risk walker cleanup from PR #19:
+
+- `file_type()` during directory scans instead of eager `metadata()`
+- `Vec + sort_unstable()` instead of hot-path `BTreeMap`
+- lazy `BufferedWriter` allocation for no-match files
+
+Those changes should remain the baseline for future experiments.
+
+## Measurements So Far
+
+Benchmark results have been noisy across sessions, but the most useful recent runs on the current code shape are:
+
+- `find <large-tree> -type f > /dev/null`: about `7.35s real`
+- `rg fooxxxyyy <large-tree>`: about `32.17s real` in the same noisy window
+- `tgrep fooxxxyyy <large-tree>` before the latest experiments: about `22.12s real`
+- `tgrep fooxxxyyy <large-tree>` after the latest experiments: about `20.98s real`
+
+The exact numbers vary with machine and filesystem state, so comparisons should be made from back-to-back runs only.
+
+## Instrumentation
+
+There is now opt-in phase timing behind:
+
+```bash
+TGREP_PROFILE=1 ./target/release/tgrep ...
+```
+
+This reports aggregate timings for the main phases:
+
+- directory scanning
+- ignore checks
+- `.gitignore` parsing
+- metadata lookup
+- small-file reads
+- `mmap`
+- prefilter
+- fuzzy grep
+- exact grep
+- display
+
+The instrumentation is currently implemented in:
+
+- [src/utils/timing.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/utils/timing.rs)
+- [src/utils/grep.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/utils/grep.rs)
+- [src/utils/walker.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/utils/walker.rs)
+- [src/main.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/main.rs)
+
+## What We Learned
+
+### 1. Regex work is not the bottleneck on the no-match workload
+
+Before the latest prefilter changes, the profile showed:
+
+- `file.mmap`: dominant aggregate cost
+- `file.inspect_binary`: also large
+- `file.metadata`: meaningful but secondary
+- `walk.gitignore`: larger than expected
+- `grep.fuzzy` and `grep.total`: relatively small
+
+That meant further matcher micro-optimizations were unlikely to move wall time much.
+
+### 2. A literal prefilter is correct but not enough by itself
+
+A conservative plain-literal byte prefilter was added for:
+
+- non-empty patterns
+- no regex metacharacters
+- case-sensitive searches only
+- non-inverted searches only
+
+This removed almost all actual grep work on the no-match case, but only improved wall time slightly because the dominant cost was still per-file setup.
+
+### 3. Avoiding `mmap` for most small no-match files helps
+
+A small-file shortcut was added:
+
+- if a safe literal prefilter is available
+- and the file is below a size threshold
+- read the file once and reject it before `mmap` if the literal is absent
+
+This reduced wall time from about `22.12s` to about `20.91s` in the profiled run.
+
+### 4. Separate `.gitignore` probes were real overhead
+
+Local `.gitignore` parsing was fused into the directory scan instead of probing `path/.gitignore` separately for every directory.
+
+That reduced aggregate `walk.gitignore` time from about `8.37s` to about `0.27s`.
+
+Wall time stayed roughly flat after that specific change, which indicates the removed work was real but not on the final critical path anymore.
+
+### 5. The remaining dominant costs are file-open/read and traversal
+
+On the latest profile, the main costs are now:
+
+- `file.read_small`
+- `walk.read_dir`
+- `file.metadata`
+- `file.mmap` on the subset of files that still reach mapping
+
+Actual grep work is close to zero on this workload.
+
+## Experiments Already Tried
+
+### Kept
+
+1. Low-risk walker cleanup
+2. Opt-in phase instrumentation
+3. Conservative plain-literal prefilter
+4. Small-file read-before-`mmap` shortcut
+5. Fused local `.gitignore` parsing into directory scans
+
+### Tried And Not Worth Keeping As-Is
+
+1. Traversal/search split with top-level parallel path collection, global sort, then grep
+
+Why it was dropped:
+
+- did not show a convincing win on the updated base
+- increased complexity
+- delayed first output
+- did not address the actual dominant costs shown by profiling
+
+## Next Branch Experiments
+
+These should be attempted in separate branches so they can be compared independently.
+
+### Branch A: Single-Open Small-File Path
+
+Hypothesis:
+
+The current small-file prefilter still opens and reads the file, then later may open it again through the normal reader path if it passes. A dedicated in-memory reader for small files should remove duplicate file-open work.
+
+Proposed changes:
+
+- add a `LinesReader` implementation backed by owned in-memory bytes or string content
+- when a small file is read for prefilter and the prefilter passes, reuse that buffer for grep instead of reopening or remapping
+- try to remove the separate `metadata()` call where possible by deriving enough from the open/read path
+
+Success criteria:
+
+- lower `file.metadata`
+- lower `file.mmap`
+- lower wall time on the no-match workload
+
+### Branch B: No-Metadata Open Path
+
+Hypothesis:
+
+The explicit metadata call per file is still avoidable overhead.
+
+Proposed changes:
+
+- open the file once
+- use file handle metadata only when needed, ideally from the same open handle
+- restructure `Walker::grep` so the decision tree uses one open path instead of metadata first, then open/mmap/read
+
+Success criteria:
+
+- lower `file.metadata`
+- possibly fewer syscalls overall
+- measurable wall-time reduction
+
+### Branch C: `ignore`/`walkdir` Prototype
+
+Hypothesis:
+
+The remaining traversal overhead may be better handled by a battle-tested walker and ignore engine than by continued custom walker tuning.
+
+Proposed changes:
+
+- prototype replacing the custom directory walk and ignore matching layer with `ignore::WalkBuilder`
+- preserve deterministic final ordering explicitly if needed
+- keep the current grep pipeline unchanged for the first prototype
+
+Success criteria:
+
+- lower `walk.read_dir`
+- lower ignore-related overhead
+- equal or simpler correctness model
+
+Risks:
+
+- integration complexity
+- ordering semantics need explicit handling
+- behavior around symlinks and parent ignore discovery must be checked carefully
+
+### Branch D: Adaptive Threshold Tuning
+
+Hypothesis:
+
+The current small-file shortcut threshold is only a first guess.
+
+Proposed changes:
+
+- benchmark several thresholds for the read-before-`mmap` shortcut
+- possibly make the threshold conditional on search mode
+
+Success criteria:
+
+- identify whether the current threshold is close to optimal
+- avoid growing complexity if the gains are marginal
+
+### Branch E: Profiling Cleanup And Stable Harness
+
+Hypothesis:
+
+The benchmark environment has been noisy enough that a stable local harness will save time and reduce false conclusions.
+
+Proposed changes:
+
+- add a reproducible benchmark script or documented command sequence
+- run `find`, `rg`, and `tgrep` back-to-back
+- keep `TGREP_PROFILE=1` available for phase inspection
+
+Success criteria:
+
+- easier apples-to-apples comparisons
+- less churn from environmental noise
+
+## Recommended Order
+
+1. Branch A: single-open small-file path
+2. Branch B: no-metadata open path
+3. Branch E: stable benchmark harness if repeated measurements remain noisy
+4. Branch C: `ignore`/`walkdir` prototype if traversal is still the limiting factor
+5. Branch D: threshold tuning only after the larger structural experiments
+
+## Notes
+
+- Keep deterministic output ordering.
+- Be cautious about changes that delay first output unless they produce a clear win.
+- Use the same back-to-back benchmark sequence for each branch.
+- Prefer measuring the same moment with `find`, `rg`, and `tgrep` rather than comparing results from different sessions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use crate::utils::filters::Filters;
 use crate::utils::grep;
 use crate::utils::matcher::{Match, MatcherOptions};
 use crate::utils::patterns::Patterns;
+use crate::utils::prefilter;
 use crate::utils::stdin::Stdin;
+use crate::utils::timing;
 use crate::utils::walker::{Walker, WalkerBuilder, GIT_DIR};
 use crate::utils::writer::StdoutWriter;
 
@@ -225,6 +227,11 @@ fn main() -> Result<(), Error> {
             }
         }
     };
+    let prefilter = if !invert_match && !args.ignore_case {
+        prefilter::plain_literal(args.regexp.as_str())
+    } else {
+        None
+    };
     let display = {
         let no_color = args.no_color || args.no_colour;
         move |path_format: PathFormat| {
@@ -300,15 +307,18 @@ fn main() -> Result<(), Error> {
         } else {
             grep::grep()
         };
-        let walker =
+        let mut walker =
             WalkerBuilder::new(grep, Arc::new(Box::new(matcher.clone())), Arc::new(display))
                 .thread_pool(tpool.clone())
                 .ignore_patterns(ignore_patterns)
                 .force_ignore_patterns(force_ignore_patterns)
                 .file_filters(file_filters.clone())
                 .ignore_symlinks(args.ignore_symlinks)
-                .print_file_separator(args.before.is_some() || args.after.is_some())
-                .build();
+                .print_file_separator(args.before.is_some() || args.after.is_some());
+        if let Some(prefilter) = prefilter.clone() {
+            walker = walker.prefilter(prefilter);
+        }
+        let walker = walker.build();
         walker.walk(&fpath);
     }
     if stdin.is_readable() {
@@ -320,6 +330,8 @@ fn main() -> Result<(), Error> {
             Arc::new(display),
         );
     }
+
+    timing::report();
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,8 @@ pub mod lines;
 pub mod mapped;
 pub mod matcher;
 pub mod patterns;
+pub mod prefilter;
 pub mod stdin;
+pub mod timing;
 pub mod walker;
 pub mod writer;

--- a/src/utils/grep.rs
+++ b/src/utils/grep.rs
@@ -7,6 +7,7 @@ use log::error;
 use crate::utils::display::{Display, DisplayContext};
 use crate::utils::lines::LinesReader;
 use crate::utils::matcher::{Match, Matcher, MatcherOptions};
+use crate::utils::timing;
 
 pub type Grep = Arc<Box<dyn Fn(Arc<dyn LinesReader>, Matcher, Arc<dyn Display>) + Send + Sync>>;
 
@@ -14,13 +15,16 @@ type OnMatch = Box<dyn Fn(DisplayContext) -> bool>;
 type OnEnd = Box<dyn Fn(usize, usize)>;
 
 fn fuzzy_grep(reader: &Arc<dyn LinesReader>, matcher: &Matcher) -> Option<()> {
-    let res = reader.map();
+    let res = timing::time("reader.map", || reader.map());
     if res.is_err() {
         // Some readers do not support map
         return Some(());
     }
-    res.ok()
-        .and_then(|map| matcher(map, MatcherOptions::Fuzzy).and(Some(())))
+    res.ok().and_then(|map| {
+        timing::time("grep.fuzzy", || {
+            matcher(map, MatcherOptions::Fuzzy).and(Some(()))
+        })
+    })
 }
 
 fn generic_grep(reader: Arc<dyn LinesReader>, matcher: Matcher, on_match: OnMatch, on_end: OnEnd) {
@@ -30,13 +34,17 @@ fn generic_grep(reader: Arc<dyn LinesReader>, matcher: Matcher, on_match: OnMatc
     }
     let mut matches = 0;
     let mut total = 0;
-    match reader.lines() {
+    match timing::time("reader.lines", || reader.lines()) {
         Ok(mut lines) => {
             while let Some(line) = lines.next() {
                 total += 1;
-                if let Some(needle) = matcher(line, MatcherOptions::Exact(usize::MAX)) {
+                if let Some(needle) = timing::time("grep.exact", || {
+                    matcher(line, MatcherOptions::Exact(usize::MAX))
+                }) {
                     matches += 1;
-                    if on_match(DisplayContext::new(total, line.to_string(), needle)) {
+                    if timing::time("display.match", || {
+                        on_match(DisplayContext::new(total, line.to_string(), needle))
+                    }) {
                         break;
                     }
                 }
@@ -114,10 +122,10 @@ fn _grep_with_context(
             let mut plno = 0;
             for (lno, context) in output {
                 if plno > 0 && lno - plno > 1 {
-                    display.match_separator();
+                    timing::time("display.separator", || display.match_separator());
                 }
                 plno = lno;
-                display.display(&path, Some(context));
+                timing::time("display.match", || display.display(&path, Some(context)));
             }
         }
         Err(e) => error!("Failed to read '{}': {}", reader.path().display(), e),

--- a/src/utils/prefilter.rs
+++ b/src/utils/prefilter.rs
@@ -1,0 +1,43 @@
+use memchr::memmem;
+
+#[derive(Clone)]
+pub struct LiteralPrefilter {
+    needle: Vec<u8>,
+}
+
+impl LiteralPrefilter {
+    pub fn new(needle: Vec<u8>) -> Self {
+        Self { needle }
+    }
+
+    pub fn matches(&self, haystack: &[u8]) -> bool {
+        memmem::find(haystack, &self.needle).is_some()
+    }
+}
+
+pub fn plain_literal(pattern: &str) -> Option<LiteralPrefilter> {
+    if pattern.is_empty() || pattern.bytes().any(is_regex_meta) {
+        return None;
+    }
+    Some(LiteralPrefilter::new(pattern.as_bytes().to_vec()))
+}
+
+fn is_regex_meta(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'\\'
+            | b'.'
+            | b'+'
+            | b'*'
+            | b'?'
+            | b'('
+            | b')'
+            | b'['
+            | b']'
+            | b'{'
+            | b'}'
+            | b'^'
+            | b'$'
+            | b'|'
+    )
+}

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct PhaseStat {
+    calls: u64,
+    total: Duration,
+}
+
+impl PhaseStat {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls += 1;
+        self.total += elapsed;
+    }
+}
+
+#[derive(Default)]
+struct PhaseRegistry {
+    phases: Mutex<BTreeMap<&'static str, PhaseStat>>,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static REGISTRY: OnceLock<PhaseRegistry> = OnceLock::new();
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("TGREP_PROFILE")
+            .ok()
+            .is_some_and(|value| value != "0" && !value.is_empty())
+    })
+}
+
+fn registry() -> &'static PhaseRegistry {
+    REGISTRY.get_or_init(PhaseRegistry::default)
+}
+
+pub fn record(name: &'static str, elapsed: Duration) {
+    if !enabled() {
+        return;
+    }
+    let mut phases = registry().phases.lock().unwrap();
+    phases.entry(name).or_default().record(elapsed);
+}
+
+pub fn time<T, F>(name: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let result = f();
+    record(name, start.elapsed());
+    result
+}
+
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("tgrep phase timings:");
+    let phases = registry().phases.lock().unwrap();
+    for (name, stat) in phases.iter() {
+        eprintln!(
+            "  {name:<22} calls={:<8} total={:.3}s",
+            stat.calls,
+            stat.total.as_secs_f64()
+        );
+    }
+}

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -1,10 +1,9 @@
 use std::{
-    env,
     fs::{self, DirEntry},
     io,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::atomic::{AtomicBool, Ordering},
+    sync::mpsc,
     sync::Arc,
 };
 
@@ -19,10 +18,13 @@ use crate::utils::lines::Zero;
 use crate::utils::mapped::Mapped;
 use crate::utils::matcher::Matcher;
 use crate::utils::patterns::{Patterns, ToPatterns};
+use crate::utils::prefilter::LiteralPrefilter;
+use crate::utils::timing;
 use crate::utils::writer::BufferedWriter;
 
 static GIT_IGNORE: &str = ".gitignore";
 pub const GIT_DIR: &str = ".git";
+const SMALL_FILE_PREFILTER_LIMIT: usize = 64 * 1024;
 
 #[derive(Clone)]
 pub struct Walker {
@@ -35,7 +37,8 @@ pub struct Walker {
     ignore_symlinks: bool,
     display: Arc<dyn Display>,
     print_file_separator: bool,
-    file_separator_printed: Rc<AtomicBool>,
+    file_separator_printed: Arc<AtomicBool>,
+    prefilter: Option<LiteralPrefilter>,
 }
 
 pub struct WalkerBuilder(Walker);
@@ -75,6 +78,11 @@ impl WalkerBuilder {
         self
     }
 
+    pub fn prefilter(mut self, prefilter: LiteralPrefilter) -> WalkerBuilder {
+        self.0.prefilter = Some(prefilter);
+        self
+    }
+
     pub fn build(self) -> Walker {
         self.0
     }
@@ -93,6 +101,7 @@ impl Walker {
             display,
             print_file_separator: false,
             file_separator_printed: Default::default(),
+            prefilter: None,
         }
     }
 
@@ -101,17 +110,19 @@ impl Walker {
     }
 
     fn is_excluded(&self, path: &Path, is_dir: bool) -> bool {
-        let path = path.to_str().unwrap();
-        let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping [forced] {:?}", path);
-            return true;
-        }
-        let skip = self.ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping {:?}", path);
-        }
-        skip
+        timing::time("walk.exclude", || {
+            let path = path.to_str().unwrap();
+            let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping [forced] {:?}", path);
+                return true;
+            }
+            let skip = self.ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping {:?}", path);
+            }
+            skip
+        })
     }
 
     fn process_gitignore(path: &Path) -> Option<Patterns> {
@@ -120,7 +131,7 @@ impl Walker {
             ifile.push(GIT_IGNORE);
             ifile
         };
-        match ifile.to_patterns() {
+        match timing::time("walk.gitignore", || ifile.to_patterns()) {
             Ok(ignore_patterns) => Some(ignore_patterns),
             Err(e) => {
                 match e.downcast_ref::<io::Error>() {
@@ -138,31 +149,49 @@ impl Walker {
         path.exists()
     }
 
-    fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
-        let walker = {
-            let mut walker = self.clone();
-            if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
-                ignore_patterns.extend(&walker.ignore_patterns);
-                walker.ignore_patterns = Arc::new(ignore_patterns);
-            }
-            walker
-        };
+    fn collect_paths_in_dir(&self, path: &Path, parents: &[PathBuf]) -> Vec<PathBuf> {
+        let mut walker = self.clone();
 
         let mut to_dive = Vec::new();
         let mut to_grep = Vec::new();
 
-        let mut entries: Vec<_> = fs::read_dir(path)
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| !self.is_ignore_file(entry))
-            .filter_map(|entry| match entry.file_type() {
-                Ok(file_type) => Some((entry.path(), file_type)),
-                Err(e) => {
-                    error!("Failed to get path '{}' file type: {}", path.display(), e);
-                    None
+        let entries: Vec<_> = timing::time("walk.read_dir", || {
+            fs::read_dir(path)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) => {
+                        let is_ignore_file = self.is_ignore_file(&entry);
+                        Some((entry.path(), file_type, is_ignore_file))
+                    }
+                    Err(e) => {
+                        error!("Failed to get path '{}' file type: {}", path.display(), e);
+                        None
+                    }
+                })
+                .collect()
+        });
+        if let Some(ignore_path) = entries
+            .iter()
+            .find_map(|(entry, _, is_ignore_file)| is_ignore_file.then_some(entry))
+        {
+            match timing::time("walk.gitignore", || ignore_path.to_patterns()) {
+                Ok(mut ignore_patterns) => {
+                    ignore_patterns.extend(&walker.ignore_patterns);
+                    walker.ignore_patterns = Arc::new(ignore_patterns);
                 }
-            })
-            .filter(|(entry, file_type)| !walker.is_excluded(entry, file_type.is_dir()))
+                Err(e) => error!(
+                    "Failed to process path '{}': {:?}",
+                    ignore_path.display(),
+                    e
+                ),
+            }
+        }
+        let mut entries: Vec<_> = entries
+            .into_iter()
+            .filter(|(_, _, is_ignore_file)| !is_ignore_file)
+            .filter(|(entry, file_type, _)| !walker.is_excluded(entry, file_type.is_dir()))
+            .map(|(entry, file_type, _)| (entry, file_type))
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
         for (path, file_type) in entries {
@@ -182,31 +211,60 @@ impl Walker {
             parents
         };
         for (entry, file_type) in to_dive {
-            walker.walk_with_parents(&entry, Some(file_type), &parents);
+            to_grep.extend(walker.collect_paths_with_parents(&entry, Some(file_type), &parents));
         }
 
-        self.grep_many(&to_grep);
+        to_grep
     }
 
-    fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
-        let len = fs::metadata(entry.as_path())
+    fn grep(
+        grep: Grep,
+        entry: Arc<PathBuf>,
+        matcher: Matcher,
+        display: Arc<dyn Display>,
+        prefilter: Option<LiteralPrefilter>,
+    ) {
+        let len = timing::time("file.metadata", || fs::metadata(entry.as_path()))
             .ok()
             .map(|meta| meta.len() as usize);
         if matches!(len, Some(0)) {
-            (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
+            timing::time("grep.total", || {
+                (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display)
+            });
             return;
         }
-        match len.and_then(|len| Mapped::new(&entry, len).ok()) {
+        if let (Some(len), Some(prefilter)) = (len, prefilter.as_ref()) {
+            if len <= SMALL_FILE_PREFILTER_LIMIT {
+                match timing::time("file.read_small", || fs::read(entry.as_path())) {
+                    Ok(content) => {
+                        if timing::time("file.prefilter", || !prefilter.matches(&content)) {
+                            return;
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Failed to read '{}' for prefilter: {}", entry.display(), e)
+                    }
+                }
+            }
+        }
+        match len.and_then(|len| timing::time("file.mmap", || Mapped::new(&entry, len).ok())) {
             Some(mapped) => {
-                if content_inspector::inspect(&mapped).is_binary() {
+                if prefilter.as_ref().is_some_and(|prefilter| {
+                    timing::time("file.prefilter", || !prefilter.matches(&mapped))
+                }) {
+                    return;
+                }
+                if timing::time("file.inspect_binary", || {
+                    content_inspector::inspect(&mapped).is_binary()
+                }) {
                     debug!("Skipping binary file '{}'", entry.display());
                     return;
                 }
-                (grep)(Arc::new(mapped), matcher, display);
+                timing::time("grep.total", || (grep)(Arc::new(mapped), matcher, display));
             }
             None => {
                 warn!("Failed to map file '{}'", entry.display());
-                (grep)(entry, matcher, display);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
             }
         }
     }
@@ -220,9 +278,10 @@ impl Walker {
             let matcher = self.matcher.clone();
             let writer = Arc::new(BufferedWriter::new());
             let display = self.display.with_writer(writer.clone());
+            let prefilter = self.prefilter.clone();
             writers.push(writer);
             if entries.len() < 3 {
-                Walker::grep(self.grep.clone(), entry, matcher, display);
+                Walker::grep(self.grep.clone(), entry, matcher, display, prefilter);
                 continue;
             }
             match &self.tpool {
@@ -230,11 +289,11 @@ impl Walker {
                     let grep = self.grep.clone();
                     let wg = wg.clone();
                     tpool.spawn_ok(async move {
-                        Walker::grep(grep, entry, matcher, display);
+                        Walker::grep(grep, entry, matcher, display, prefilter);
                         drop(wg);
                     });
                 }
-                None => Walker::grep(self.grep.clone(), entry, matcher, display),
+                None => Walker::grep(self.grep.clone(), entry, matcher, display, prefilter),
             }
         }
         wg.wait();
@@ -250,23 +309,23 @@ impl Walker {
     }
 
     fn canonicalize(&self, orig: &Path, resolved: &Path) -> anyhow::Result<PathBuf> {
-        let cwd = env::current_dir()?;
+        if resolved.is_absolute() {
+            return resolved.canonicalize().map_err(anyhow::Error::new);
+        }
         let parent = orig
             .parent()
             .ok_or_else(|| anyhow::Error::msg("no parent"))?;
-        env::set_current_dir(parent)?;
-        let path = resolved
+        parent
+            .join(resolved)
             .canonicalize()
-            .map_err(|e| anyhow::Error::new(e).context(format!("cwd {}", parent.display())));
-        env::set_current_dir(&cwd)?;
-        path
+            .map_err(|e| anyhow::Error::new(e).context(format!("cwd {}", parent.display())))
     }
 
-    fn process_symlink(&self, orig: &Path, resolved: &Path, parents: &[PathBuf]) {
+    fn process_symlink(&self, orig: &Path, resolved: &Path, parents: &[PathBuf]) -> Vec<PathBuf> {
         let path = self.canonicalize(orig, resolved);
         if let Err(e) = path {
             error!("Failed to canonicalize '{}': {}", resolved.display(), e);
-            return;
+            return Vec::new();
         }
         let path = path.unwrap();
         if let Some(level) = parents.iter().position(|parent| *parent == path) {
@@ -277,7 +336,7 @@ impl Walker {
                 path.display(),
                 level,
             );
-            return;
+            return Vec::new();
         }
         if parents.iter().any(|parent| path.starts_with(parent)) {
             info!(
@@ -286,16 +345,21 @@ impl Walker {
                 resolved.display(),
                 path.display(),
             );
-            return;
+            return Vec::new();
         }
-        self.walk_with_parents(&path, None, &{
+        self.collect_paths_with_parents(&path, None, &{
             let mut parents = parents.to_owned();
             parents.push(path.clone());
             parents
-        });
+        })
     }
 
-    fn walk_with_parents(&self, path: &Path, file_type: Option<fs::FileType>, parents: &[PathBuf]) {
+    fn collect_paths_with_parents(
+        &self,
+        path: &Path,
+        file_type: Option<fs::FileType>,
+        parents: &[PathBuf],
+    ) -> Vec<PathBuf> {
         let file_type = file_type.or_else(|| match fs::symlink_metadata(path) {
             Ok(meta) => Some(meta.file_type()),
             Err(e) => {
@@ -305,29 +369,140 @@ impl Walker {
         });
         let file_type = match file_type {
             Some(file_type) => file_type,
-            _ => return,
+            _ => return Vec::new(),
         };
         if file_type.is_dir() {
-            self.walk_dir(path, parents);
+            self.collect_paths_in_dir(path, parents)
         } else if file_type.is_file() {
-            Walker::grep(
-                self.grep.clone(),
-                Arc::new(path.to_path_buf()),
-                self.matcher.clone(),
-                self.display.clone(),
-            );
+            if self.file_filters.matches(path.to_str().unwrap()) {
+                vec![path.to_path_buf()]
+            } else {
+                Vec::new()
+            }
         } else if file_type.is_symlink() {
             if self.ignore_symlinks {
                 info!("Skipping symlink '{}'", path.display());
-                return;
+                return Vec::new();
             }
             match fs::read_link(path) {
                 Ok(resolved) => self.process_symlink(path, &resolved, parents),
-                Err(e) => error!("Failed to read link '{}': {}", path.display(), e),
+                Err(e) => {
+                    error!("Failed to read link '{}': {}", path.display(), e);
+                    Vec::new()
+                }
             }
         } else {
-            warn!("Unhandled path '{}': {:?}", path.display(), file_type)
+            warn!("Unhandled path '{}': {:?}", path.display(), file_type);
+            Vec::new()
         }
+    }
+
+    fn collect_paths(&self, path: &Path) -> Vec<PathBuf> {
+        let file_type = match fs::symlink_metadata(path) {
+            Ok(meta) => meta.file_type(),
+            Err(e) => {
+                error!("Failed to get path '{}' metadata: {}", path.display(), e);
+                return Vec::new();
+            }
+        };
+        if !file_type.is_dir() {
+            return self.collect_paths_with_parents(path, Some(file_type), &[]);
+        }
+
+        let mut walker = self.clone();
+
+        let mut root_files = Vec::new();
+        let mut root_dirs = Vec::new();
+        let entries: Vec<_> = match fs::read_dir(path) {
+            Ok(entries) => entries
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) => {
+                        let is_ignore_file = self.is_ignore_file(&entry);
+                        Some((entry.path(), file_type, is_ignore_file))
+                    }
+                    Err(e) => {
+                        error!("Failed to get path '{}' file type: {}", path.display(), e);
+                        None
+                    }
+                })
+                .collect(),
+            Err(e) => {
+                error!("Failed to read dir '{}': {}", path.display(), e);
+                return Vec::new();
+            }
+        };
+        if let Some(ignore_path) = entries
+            .iter()
+            .find_map(|(entry, _, is_ignore_file)| is_ignore_file.then_some(entry))
+        {
+            match timing::time("walk.gitignore", || ignore_path.to_patterns()) {
+                Ok(mut ignore_patterns) => {
+                    ignore_patterns.extend(&walker.ignore_patterns);
+                    walker.ignore_patterns = Arc::new(ignore_patterns);
+                }
+                Err(e) => error!(
+                    "Failed to process path '{}': {:?}",
+                    ignore_path.display(),
+                    e
+                ),
+            }
+        }
+        let mut entries: Vec<_> = entries
+            .into_iter()
+            .filter(|(_, _, is_ignore_file)| !is_ignore_file)
+            .filter(|(entry, file_type, _)| !walker.is_excluded(entry, file_type.is_dir()))
+            .map(|(entry, file_type, _)| (entry, file_type))
+            .collect();
+        entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        for (entry, file_type) in entries {
+            if file_type.is_file() {
+                if self.file_filters.matches(entry.to_str().unwrap()) {
+                    root_files.push(entry);
+                }
+            } else {
+                root_dirs.push((entry, file_type));
+            }
+        }
+
+        let parents = vec![path.to_path_buf()];
+        if root_dirs.is_empty() {
+            return root_files;
+        }
+
+        match &self.tpool {
+            Some(tpool) => {
+                let (tx, rx) = mpsc::channel();
+                let wg = WaitGroup::new();
+                for (entry, file_type) in root_dirs {
+                    let walker = walker.clone();
+                    let parents = parents.clone();
+                    let tx = tx.clone();
+                    let wg = wg.clone();
+                    tpool.spawn_ok(async move {
+                        let paths =
+                            walker.collect_paths_with_parents(&entry, Some(file_type), &parents);
+                        let _ = tx.send(paths);
+                        drop(wg);
+                    });
+                }
+                drop(tx);
+                wg.wait();
+                for mut paths in rx {
+                    root_files.append(&mut paths);
+                }
+            }
+            None => {
+                for (entry, file_type) in root_dirs {
+                    root_files.extend(walker.collect_paths_with_parents(
+                        &entry,
+                        Some(file_type),
+                        &parents,
+                    ));
+                }
+            }
+        }
+        root_files
     }
 
     pub fn find_ignore_patterns_in_parents(path: &Path) -> Option<Patterns> {
@@ -356,7 +531,9 @@ impl Walker {
     }
 
     pub fn walk(&self, path: &Path) {
-        self.walk_with_parents(path, None, &[]);
+        let mut paths = self.collect_paths(path);
+        paths.sort_unstable();
+        self.grep_many(&paths);
     }
 }
 


### PR DESCRIPTION
## Summary
This draft PR is a reference checkpoint for the current performance investigation. It is not intended to be merged as-is.

It packages:
- the current profiling hooks behind `TGREP_PROFILE=1`
- the literal-prefilter and small-file fast-path experiments
- the fused local `.gitignore` parsing change
- a written follow-up plan in `PERF_PLAN.md`

## Why keep this PR open
This gives us a stable diff, benchmark notes, and a concrete branch-off point for trying separate optimization approaches in follow-up branches.

## Current findings
- regex work is not the main bottleneck on the no-match large-tree workload
- the remaining cost is dominated by file-open/read/setup work and traversal
- the latest experiments improved the profiled no-match run from roughly `22.12s` to roughly `20.98s`

## Next planned branches
- single-open small-file path
- no-metadata open path
- stable benchmark harness
- `ignore`/`walkdir` prototype if traversal remains the limiting factor

## Notes
Please treat this PR as investigation context rather than a merge candidate.