### PR TITLE
Experiment: small-file search path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use crate::utils::filters::Filters;
 use crate::utils::grep;
 use crate::utils::matcher::{Match, MatcherOptions};
 use crate::utils::patterns::Patterns;
+use crate::utils::prefilter;
 use crate::utils::stdin::Stdin;
+use crate::utils::timing;
 use crate::utils::walker::{Walker, WalkerBuilder, GIT_DIR};
 use crate::utils::writer::StdoutWriter;
 
@@ -225,6 +227,11 @@ fn main() -> Result<(), Error> {
             }
         }
     };
+    let prefilter = if !invert_match && !args.ignore_case {
+        prefilter::plain_literal(args.regexp.as_str())
+    } else {
+        None
+    };
     let display = {
         let no_color = args.no_color || args.no_colour;
         move |path_format: PathFormat| {
@@ -300,15 +307,18 @@ fn main() -> Result<(), Error> {
         } else {
             grep::grep()
         };
-        let walker =
+        let mut walker =
             WalkerBuilder::new(grep, Arc::new(Box::new(matcher.clone())), Arc::new(display))
                 .thread_pool(tpool.clone())
                 .ignore_patterns(ignore_patterns)
                 .force_ignore_patterns(force_ignore_patterns)
                 .file_filters(file_filters.clone())
                 .ignore_symlinks(args.ignore_symlinks)
-                .print_file_separator(args.before.is_some() || args.after.is_some())
-                .build();
+                .print_file_separator(args.before.is_some() || args.after.is_some());
+        if let Some(prefilter) = prefilter.clone() {
+            walker = walker.prefilter(prefilter);
+        }
+        let walker = walker.build();
         walker.walk(&fpath);
     }
     if stdin.is_readable() {
@@ -320,6 +330,8 @@ fn main() -> Result<(), Error> {
             Arc::new(display),
         );
     }
+
+    timing::report();
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,8 @@ pub mod lines;
 pub mod mapped;
 pub mod matcher;
 pub mod patterns;
+pub mod prefilter;
 pub mod stdin;
+pub mod timing;
 pub mod walker;
 pub mod writer;

--- a/src/utils/grep.rs
+++ b/src/utils/grep.rs
@@ -7,6 +7,7 @@ use log::error;
 use crate::utils::display::{Display, DisplayContext};
 use crate::utils::lines::LinesReader;
 use crate::utils::matcher::{Match, Matcher, MatcherOptions};
+use crate::utils::timing;
 
 pub type Grep = Arc<Box<dyn Fn(Arc<dyn LinesReader>, Matcher, Arc<dyn Display>) + Send + Sync>>;
 
@@ -14,13 +15,16 @@ type OnMatch = Box<dyn Fn(DisplayContext) -> bool>;
 type OnEnd = Box<dyn Fn(usize, usize)>;
 
 fn fuzzy_grep(reader: &Arc<dyn LinesReader>, matcher: &Matcher) -> Option<()> {
-    let res = reader.map();
+    let res = timing::time("reader.map", || reader.map());
     if res.is_err() {
         // Some readers do not support map
         return Some(());
     }
-    res.ok()
-        .and_then(|map| matcher(map, MatcherOptions::Fuzzy).and(Some(())))
+    res.ok().and_then(|map| {
+        timing::time("grep.fuzzy", || {
+            matcher(map, MatcherOptions::Fuzzy).and(Some(()))
+        })
+    })
 }
 
 fn generic_grep(reader: Arc<dyn LinesReader>, matcher: Matcher, on_match: OnMatch, on_end: OnEnd) {
@@ -30,13 +34,17 @@ fn generic_grep(reader: Arc<dyn LinesReader>, matcher: Matcher, on_match: OnMatc
     }
     let mut matches = 0;
     let mut total = 0;
-    match reader.lines() {
+    match timing::time("reader.lines", || reader.lines()) {
         Ok(mut lines) => {
             while let Some(line) = lines.next() {
                 total += 1;
-                if let Some(needle) = matcher(line, MatcherOptions::Exact(usize::MAX)) {
+                if let Some(needle) = timing::time("grep.exact", || {
+                    matcher(line, MatcherOptions::Exact(usize::MAX))
+                }) {
                     matches += 1;
-                    if on_match(DisplayContext::new(total, line.to_string(), needle)) {
+                    if timing::time("display.match", || {
+                        on_match(DisplayContext::new(total, line.to_string(), needle))
+                    }) {
                         break;
                     }
                 }
@@ -114,10 +122,10 @@ fn _grep_with_context(
             let mut plno = 0;
             for (lno, context) in output {
                 if plno > 0 && lno - plno > 1 {
-                    display.match_separator();
+                    timing::time("display.separator", || display.match_separator());
                 }
                 plno = lno;
-                display.display(&path, Some(context));
+                timing::time("display.match", || display.display(&path, Some(context)));
             }
         }
         Err(e) => error!("Failed to read '{}': {}", reader.path().display(), e),

--- a/src/utils/lines.rs
+++ b/src/utils/lines.rs
@@ -1,10 +1,14 @@
 use std::{
     fs::File,
     io::{self, BufRead},
+    ops,
     path::PathBuf,
+    str,
+    sync::Arc,
 };
 
 use log::{debug, warn};
+use memchr::memchr;
 // See https://users.rust-lang.org/t/unconstrained-lifetime-parameter-for-impl/27995
 use streaming_iterator::StreamingIterator;
 
@@ -95,6 +99,102 @@ where
     }
 }
 
+struct OwnedLinesInner {
+    path: PathBuf,
+    content: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct OwnedLinesReader {
+    inner: Arc<OwnedLinesInner>,
+}
+
+impl OwnedLinesReader {
+    pub fn new(path: PathBuf, content: Vec<u8>) -> Self {
+        Self {
+            inner: Arc::new(OwnedLinesInner { path, content }),
+        }
+    }
+}
+
+impl LinesReader for OwnedLinesReader {
+    fn map(&self) -> anyhow::Result<&str> {
+        str::from_utf8(&self.inner.content).map_err(anyhow::Error::new)
+    }
+
+    fn lines(&self) -> anyhow::Result<Box<LineIterator>> {
+        Ok(Box::new(OwnedLines::new(self.inner.clone())))
+    }
+
+    fn path(&self) -> &PathBuf {
+        &self.inner.path
+    }
+}
+
+struct OwnedLines {
+    inner: Arc<OwnedLinesInner>,
+    line: ops::Range<usize>,
+    pos: usize,
+    buf: String,
+}
+
+impl OwnedLines {
+    fn new(inner: Arc<OwnedLinesInner>) -> Self {
+        Self {
+            inner,
+            line: ops::Range { start: 0, end: 0 },
+            pos: 0,
+            buf: String::new(),
+        }
+    }
+}
+
+impl StreamingIterator for OwnedLines {
+    type Item = str;
+
+    fn advance(&mut self) {
+        let content = &self.inner.content;
+        self.line.start = self.pos;
+        if self.line.start >= content.len() {
+            return;
+        }
+        self.line.end = match memchr(b'\n', &content[self.line.start..]) {
+            Some(pos) => self.line.start + pos,
+            None => content.len(),
+        };
+        self.pos = self.line.end + 1;
+        if self.line.end > self.line.start && content[self.line.end - 1] == b'\r' {
+            self.line.end -= 1;
+        }
+    }
+
+    fn get(&self) -> Option<&Self::Item> {
+        panic!("Should not be called");
+    }
+
+    fn next(&mut self) -> Option<&Self::Item> {
+        self.advance();
+        if self.line.start >= self.inner.content.len() {
+            return None;
+        }
+        let line = &self.inner.content[self.line.start..self.line.end];
+        match str::from_utf8(line) {
+            Ok(line) => Some(line),
+            Err(e) => {
+                self.buf = line.iter().map(|&c| c as char).collect();
+                debug!(
+                    "UTF-8 decoding failure of '{}' at [{};{}], transformed to '{}'",
+                    self.inner.path.display(),
+                    self.line.start + e.valid_up_to(),
+                    self.line.start + e.valid_up_to() + e.error_len().unwrap_or(0),
+                    self.buf,
+                );
+                Some(&self.buf)
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialOrd, PartialEq, Ord, Eq)]
 pub struct Zero {
     path: PathBuf,
@@ -158,6 +258,20 @@ mod tests {
         assert_eq!("", LinesReader::map(&zero).unwrap());
 
         let mut lines = zero.lines().unwrap();
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn owned_lines_reader_maps_and_iterates() {
+        let reader =
+            OwnedLinesReader::new(PathBuf::from("input.txt"), b"alpha\nbeta\r\ngamma".to_vec());
+
+        assert_eq!("alpha\nbeta\r\ngamma", LinesReader::map(&reader).unwrap());
+
+        let mut lines = reader.lines().unwrap();
+        assert_eq!(Some("alpha"), lines.next());
+        assert_eq!(Some("beta"), lines.next());
+        assert_eq!(Some("gamma"), lines.next());
         assert_eq!(None, lines.next());
     }
 }

--- a/src/utils/prefilter.rs
+++ b/src/utils/prefilter.rs
@@ -1,0 +1,43 @@
+use memchr::memmem;
+
+#[derive(Clone)]
+pub struct LiteralPrefilter {
+    needle: Vec<u8>,
+}
+
+impl LiteralPrefilter {
+    pub fn new(needle: Vec<u8>) -> Self {
+        Self { needle }
+    }
+
+    pub fn matches(&self, haystack: &[u8]) -> bool {
+        memmem::find(haystack, &self.needle).is_some()
+    }
+}
+
+pub fn plain_literal(pattern: &str) -> Option<LiteralPrefilter> {
+    if pattern.is_empty() || pattern.bytes().any(is_regex_meta) {
+        return None;
+    }
+    Some(LiteralPrefilter::new(pattern.as_bytes().to_vec()))
+}
+
+fn is_regex_meta(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'\\'
+            | b'.'
+            | b'+'
+            | b'*'
+            | b'?'
+            | b'('
+            | b')'
+            | b'['
+            | b']'
+            | b'{'
+            | b'}'
+            | b'^'
+            | b'$'
+            | b'|'
+    )
+}

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct PhaseStat {
+    calls: u64,
+    total: Duration,
+}
+
+impl PhaseStat {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls += 1;
+        self.total += elapsed;
+    }
+}
+
+#[derive(Default)]
+struct PhaseRegistry {
+    phases: Mutex<BTreeMap<&'static str, PhaseStat>>,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static REGISTRY: OnceLock<PhaseRegistry> = OnceLock::new();
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("TGREP_PROFILE")
+            .ok()
+            .is_some_and(|value| value != "0" && !value.is_empty())
+    })
+}
+
+fn registry() -> &'static PhaseRegistry {
+    REGISTRY.get_or_init(PhaseRegistry::default)
+}
+
+pub fn record(name: &'static str, elapsed: Duration) {
+    if !enabled() {
+        return;
+    }
+    let mut phases = registry().phases.lock().unwrap();
+    phases.entry(name).or_default().record(elapsed);
+}
+
+pub fn time<T, F>(name: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let result = f();
+    record(name, start.elapsed());
+    result
+}
+
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("tgrep phase timings:");
+    let phases = registry().phases.lock().unwrap();
+    for (name, stat) in phases.iter() {
+        eprintln!(
+            "  {name:<22} calls={:<8} total={:.3}s",
+            stat.calls,
+            stat.total.as_secs_f64()
+        );
+    }
+}

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -3,7 +3,6 @@ use std::{
     fs::{self, DirEntry},
     io,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
 };
@@ -15,14 +14,17 @@ use log::{debug, error, info, warn};
 use crate::utils::display::Display;
 use crate::utils::filters::Filters;
 use crate::utils::grep::Grep;
-use crate::utils::lines::Zero;
+use crate::utils::lines::{OwnedLinesReader, Zero};
 use crate::utils::mapped::Mapped;
 use crate::utils::matcher::Matcher;
 use crate::utils::patterns::{Patterns, ToPatterns};
+use crate::utils::prefilter::LiteralPrefilter;
+use crate::utils::timing;
 use crate::utils::writer::BufferedWriter;
 
 static GIT_IGNORE: &str = ".gitignore";
 pub const GIT_DIR: &str = ".git";
+const SMALL_FILE_PREFILTER_LIMIT: usize = 64 * 1024;
 
 #[derive(Clone)]
 pub struct Walker {
@@ -35,7 +37,8 @@ pub struct Walker {
     ignore_symlinks: bool,
     display: Arc<dyn Display>,
     print_file_separator: bool,
-    file_separator_printed: Rc<AtomicBool>,
+    file_separator_printed: Arc<AtomicBool>,
+    prefilter: Option<LiteralPrefilter>,
 }
 
 pub struct WalkerBuilder(Walker);
@@ -75,6 +78,11 @@ impl WalkerBuilder {
         self
     }
 
+    pub fn prefilter(mut self, prefilter: LiteralPrefilter) -> WalkerBuilder {
+        self.0.prefilter = Some(prefilter);
+        self
+    }
+
     pub fn build(self) -> Walker {
         self.0
     }
@@ -93,6 +101,7 @@ impl Walker {
             display,
             print_file_separator: false,
             file_separator_printed: Default::default(),
+            prefilter: None,
         }
     }
 
@@ -101,17 +110,19 @@ impl Walker {
     }
 
     fn is_excluded(&self, path: &Path, is_dir: bool) -> bool {
-        let path = path.to_str().unwrap();
-        let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping [forced] {:?}", path);
-            return true;
-        }
-        let skip = self.ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping {:?}", path);
-        }
-        skip
+        timing::time("walk.exclude", || {
+            let path = path.to_str().unwrap();
+            let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping [forced] {:?}", path);
+                return true;
+            }
+            let skip = self.ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping {:?}", path);
+            }
+            skip
+        })
     }
 
     fn process_gitignore(path: &Path) -> Option<Patterns> {
@@ -120,7 +131,7 @@ impl Walker {
             ifile.push(GIT_IGNORE);
             ifile
         };
-        match ifile.to_patterns() {
+        match timing::time("walk.gitignore", || ifile.to_patterns()) {
             Ok(ignore_patterns) => Some(ignore_patterns),
             Err(e) => {
                 match e.downcast_ref::<io::Error>() {
@@ -139,7 +150,7 @@ impl Walker {
     }
 
     fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
-        let walker = {
+        let mut walker = {
             let mut walker = self.clone();
             if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
                 ignore_patterns.extend(&walker.ignore_patterns);
@@ -151,18 +162,43 @@ impl Walker {
         let mut to_dive = Vec::new();
         let mut to_grep = Vec::new();
 
-        let mut entries: Vec<_> = fs::read_dir(path)
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| !self.is_ignore_file(entry))
-            .filter_map(|entry| match entry.file_type() {
-                Ok(file_type) => Some((entry.path(), file_type)),
-                Err(e) => {
-                    error!("Failed to get path '{}' file type: {}", path.display(), e);
-                    None
+        let entries: Vec<_> = timing::time("walk.read_dir", || {
+            fs::read_dir(path)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) => {
+                        let is_ignore_file = self.is_ignore_file(&entry);
+                        Some((entry.path(), file_type, is_ignore_file))
+                    }
+                    Err(e) => {
+                        error!("Failed to get path '{}' file type: {}", path.display(), e);
+                        None
+                    }
+                })
+                .collect()
+        });
+        if let Some(ignore_path) = entries
+            .iter()
+            .find_map(|(entry, _, is_ignore_file)| is_ignore_file.then_some(entry))
+        {
+            match timing::time("walk.gitignore", || ignore_path.to_patterns()) {
+                Ok(mut ignore_patterns) => {
+                    ignore_patterns.extend(&walker.ignore_patterns);
+                    walker.ignore_patterns = Arc::new(ignore_patterns);
                 }
-            })
-            .filter(|(entry, file_type)| !walker.is_excluded(entry, file_type.is_dir()))
+                Err(e) => error!(
+                    "Failed to process path '{}': {:?}",
+                    ignore_path.display(),
+                    e
+                ),
+            }
+        }
+        let mut entries: Vec<_> = entries
+            .into_iter()
+            .filter(|(_, _, is_ignore_file)| !is_ignore_file)
+            .filter(|(entry, file_type, _)| !walker.is_excluded(entry, file_type.is_dir()))
+            .map(|(entry, file_type, _)| (entry, file_type))
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
         for (path, file_type) in entries {
@@ -188,25 +224,63 @@ impl Walker {
         self.grep_many(&to_grep);
     }
 
-    fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
-        let len = fs::metadata(entry.as_path())
+    fn grep(
+        grep: Grep,
+        entry: Arc<PathBuf>,
+        matcher: Matcher,
+        display: Arc<dyn Display>,
+        prefilter: Option<LiteralPrefilter>,
+    ) {
+        let len = timing::time("file.metadata", || fs::metadata(entry.as_path()))
             .ok()
             .map(|meta| meta.len() as usize);
         if matches!(len, Some(0)) {
-            (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
+            timing::time("grep.total", || {
+                (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display)
+            });
             return;
         }
-        match len.and_then(|len| Mapped::new(&entry, len).ok()) {
+        if let (Some(len), Some(prefilter)) = (len, prefilter.as_ref()) {
+            if len <= SMALL_FILE_PREFILTER_LIMIT {
+                match timing::time("file.read_small", || fs::read(entry.as_path())) {
+                    Ok(content) => {
+                        if timing::time("file.prefilter", || !prefilter.matches(&content)) {
+                            return;
+                        }
+                        if timing::time("file.inspect_binary", || {
+                            content_inspector::inspect(&content).is_binary()
+                        }) {
+                            debug!("Skipping binary file '{}'", entry.display());
+                            return;
+                        }
+                        let reader = Arc::new(OwnedLinesReader::new((*entry).clone(), content));
+                        timing::time("grep.total", || (grep)(reader, matcher, display));
+                        return;
+                    }
+                    Err(e) => {
+                        debug!("Failed to read '{}' for prefilter: {}", entry.display(), e)
+                    }
+                }
+            }
+        }
+        match len.and_then(|len| timing::time("file.mmap", || Mapped::new(&entry, len).ok())) {
             Some(mapped) => {
-                if content_inspector::inspect(&mapped).is_binary() {
+                if prefilter.as_ref().is_some_and(|prefilter| {
+                    timing::time("file.prefilter", || !prefilter.matches(&mapped))
+                }) {
+                    return;
+                }
+                if timing::time("file.inspect_binary", || {
+                    content_inspector::inspect(&mapped).is_binary()
+                }) {
                     debug!("Skipping binary file '{}'", entry.display());
                     return;
                 }
-                (grep)(Arc::new(mapped), matcher, display);
+                timing::time("grep.total", || (grep)(Arc::new(mapped), matcher, display));
             }
             None => {
                 warn!("Failed to map file '{}'", entry.display());
-                (grep)(entry, matcher, display);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
             }
         }
     }
@@ -220,9 +294,10 @@ impl Walker {
             let matcher = self.matcher.clone();
             let writer = Arc::new(BufferedWriter::new());
             let display = self.display.with_writer(writer.clone());
+            let prefilter = self.prefilter.clone();
             writers.push(writer);
             if entries.len() < 3 {
-                Walker::grep(self.grep.clone(), entry, matcher, display);
+                Walker::grep(self.grep.clone(), entry, matcher, display, prefilter);
                 continue;
             }
             match &self.tpool {
@@ -230,11 +305,11 @@ impl Walker {
                     let grep = self.grep.clone();
                     let wg = wg.clone();
                     tpool.spawn_ok(async move {
-                        Walker::grep(grep, entry, matcher, display);
+                        Walker::grep(grep, entry, matcher, display, prefilter);
                         drop(wg);
                     });
                 }
-                None => Walker::grep(self.grep.clone(), entry, matcher, display),
+                None => Walker::grep(self.grep.clone(), entry, matcher, display, prefilter),
             }
         }
         wg.wait();
@@ -315,6 +390,7 @@ impl Walker {
                 Arc::new(path.to_path_buf()),
                 self.matcher.clone(),
                 self.display.clone(),
+                self.prefilter.clone(),
             );
         } else if file_type.is_symlink() {
             if self.ignore_symlinks {


### PR DESCRIPTION
## Summary
This draft PR captures the small-file search-path experiment.

It adds:
- opt-in phase profiling behind `TGREP_PROFILE=1`
- a conservative plain-literal prefilter
- an owned small-file reader so small files that pass the prefilter are searched from already-loaded bytes instead of being reopened/remapped

## Result
On the current large-tree no-match benchmark in this environment:
- before: `23.74s real`
- after: `22.65s real`

The improvement is measurable but modest.

## What this experiment shows
- avoiding the second open/remap for small files helps
- this is not the main remaining bottleneck
- the remaining cost is still mostly in file setup and traversal work

## Notes
This PR is intended as an experiment checkpoint, not as the final optimization direction. The next optimization should likely be tried from a fresh branch off `main` for a cleaner comparison.