### PR TITLE
Experiment: no-metadata open path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use crate::utils::grep;
 use crate::utils::matcher::{Match, MatcherOptions};
 use crate::utils::patterns::Patterns;
 use crate::utils::stdin::Stdin;
+use crate::utils::timing;
 use crate::utils::walker::{Walker, WalkerBuilder, GIT_DIR};
 use crate::utils::writer::StdoutWriter;
 
@@ -320,6 +321,8 @@ fn main() -> Result<(), Error> {
             Arc::new(display),
         );
     }
+
+    timing::report();
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,5 +6,6 @@ pub mod mapped;
 pub mod matcher;
 pub mod patterns;
 pub mod stdin;
+pub mod timing;
 pub mod walker;
 pub mod writer;

--- a/src/utils/mapped.rs
+++ b/src/utils/mapped.rs
@@ -1,9 +1,4 @@
-use std::{
-    fs, ops,
-    path::{Path, PathBuf},
-    str,
-    sync::Arc,
-};
+use std::{fs::File, ops, path::PathBuf, str, sync::Arc};
 
 use log::debug;
 use memchr::memchr;
@@ -22,14 +17,10 @@ pub struct Mapped {
 }
 
 impl Mapped {
-    pub fn new(path: &Path, len: usize) -> anyhow::Result<Self> {
-        let file = fs::File::open(path)?;
+    pub fn from_file(path: PathBuf, file: File, len: usize) -> anyhow::Result<Self> {
         let mmap = unsafe { MmapOptions::new().len(len).map(&file)? };
         Ok(Mapped {
-            mapped: Arc::new(MappedInner {
-                path: path.to_owned(),
-                mmap,
-            }),
+            mapped: Arc::new(MappedInner { path, mmap }),
         })
     }
 }
@@ -123,7 +114,7 @@ impl StreamingIterator for MappedLines {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::fs::{self, File};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
@@ -158,7 +149,12 @@ mod tests {
     #[test]
     fn mapped_reader_returns_lines() {
         let file = TempFile::new(b"alpha\nbeta\ngamma");
-        let mapped = Mapped::new(file.path(), 16).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            16,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -170,7 +166,12 @@ mod tests {
     #[test]
     fn mapped_reader_trims_cr_before_lf() {
         let file = TempFile::new(b"alpha\r\nbeta\r\n");
-        let mapped = Mapped::new(file.path(), 13).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            13,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -181,7 +182,12 @@ mod tests {
     #[test]
     fn mapped_reader_falls_back_for_invalid_utf8() {
         let file = TempFile::new(b"ok\nf\x80o\n");
-        let mapped = Mapped::new(file.path(), 7).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            7,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("ok"), lines.next());

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct PhaseStat {
+    calls: u64,
+    total: Duration,
+}
+
+impl PhaseStat {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls += 1;
+        self.total += elapsed;
+    }
+}
+
+#[derive(Default)]
+struct PhaseRegistry {
+    phases: Mutex<BTreeMap<&'static str, PhaseStat>>,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static REGISTRY: OnceLock<PhaseRegistry> = OnceLock::new();
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("TGREP_PROFILE")
+            .ok()
+            .is_some_and(|value| value != "0" && !value.is_empty())
+    })
+}
+
+fn registry() -> &'static PhaseRegistry {
+    REGISTRY.get_or_init(PhaseRegistry::default)
+}
+
+pub fn time<T, F>(name: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let result = f();
+    let mut phases = registry().phases.lock().unwrap();
+    phases.entry(name).or_default().record(start.elapsed());
+    result
+}
+
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("tgrep phase timings:");
+    let phases = registry().phases.lock().unwrap();
+    for (name, stat) in phases.iter() {
+        eprintln!(
+            "  {name:<22} calls={:<8} total={:.3}s",
+            stat.calls,
+            stat.total.as_secs_f64()
+        );
+    }
+}

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -19,6 +19,7 @@ use crate::utils::lines::Zero;
 use crate::utils::mapped::Mapped;
 use crate::utils::matcher::Matcher;
 use crate::utils::patterns::{Patterns, ToPatterns};
+use crate::utils::timing;
 use crate::utils::writer::BufferedWriter;
 
 static GIT_IGNORE: &str = ".gitignore";
@@ -189,24 +190,43 @@ impl Walker {
     }
 
     fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
-        let len = fs::metadata(entry.as_path())
-            .ok()
-            .map(|meta| meta.len() as usize);
-        if matches!(len, Some(0)) {
-            (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
+        let file = match timing::time("file.open", || fs::File::open(entry.as_path())) {
+            Ok(file) => file,
+            Err(e) => {
+                warn!("Failed to open file '{}': {}", entry.display(), e);
+                (grep)(entry, matcher, display);
+                return;
+            }
+        };
+        let len = match timing::time("file.metadata", || file.metadata()) {
+            Ok(meta) => meta.len() as usize,
+            Err(e) => {
+                warn!("Failed to get file metadata '{}': {}", entry.display(), e);
+                (grep)(entry, matcher, display);
+                return;
+            }
+        };
+        if len == 0 {
+            timing::time("grep.total", || {
+                (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display)
+            });
             return;
         }
-        match len.and_then(|len| Mapped::new(&entry, len).ok()) {
+        match timing::time("file.mmap", || {
+            Mapped::from_file((*entry).clone(), file, len).ok()
+        }) {
             Some(mapped) => {
-                if content_inspector::inspect(&mapped).is_binary() {
+                if timing::time("file.inspect_binary", || {
+                    content_inspector::inspect(&mapped).is_binary()
+                }) {
                     debug!("Skipping binary file '{}'", entry.display());
                     return;
                 }
-                (grep)(Arc::new(mapped), matcher, display);
+                timing::time("grep.total", || (grep)(Arc::new(mapped), matcher, display));
             }
             None => {
                 warn!("Failed to map file '{}'", entry.display());
-                (grep)(entry, matcher, display);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
             }
         }
     }


### PR DESCRIPTION
## Summary
This draft PR captures the no-metadata open-path experiment.

It adds:
- opt-in phase profiling behind `TGREP_PROFILE=1`
- a file-read path that opens the file once, derives metadata from that handle, and reuses the same handle for `mmap`

## Result
On the current large-tree no-match benchmark in this environment:
- before: `23.74s real`
- after: `22.56s real`

The improvement is measurable but still modest.

## What this experiment shows
- the separate `metadata()` pass was real overhead
- removing it helps, but it is not the main bottleneck
- the remaining cost is still dominated by file open, binary inspection, and mapping/setup work

## Notes
This PR is intended as an experiment checkpoint, not as the final optimization direction. The next optimization should continue from a fresh branch off `main` for a cleaner comparison.