### PR TITLE
Experiment: gitignore walker path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use crate::utils::grep;
 use crate::utils::matcher::{Match, MatcherOptions};
 use crate::utils::patterns::Patterns;
 use crate::utils::stdin::Stdin;
+use crate::utils::timing;
 use crate::utils::walker::{Walker, WalkerBuilder, GIT_DIR};
 use crate::utils::writer::StdoutWriter;
 
@@ -320,6 +321,8 @@ fn main() -> Result<(), Error> {
             Arc::new(display),
         );
     }
+
+    timing::report();
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,5 +6,6 @@ pub mod mapped;
 pub mod matcher;
 pub mod patterns;
 pub mod stdin;
+pub mod timing;
 pub mod walker;
 pub mod writer;

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct PhaseStat {
+    calls: u64,
+    total: Duration,
+}
+
+impl PhaseStat {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls += 1;
+        self.total += elapsed;
+    }
+}
+
+#[derive(Default)]
+struct PhaseRegistry {
+    phases: Mutex<BTreeMap<&'static str, PhaseStat>>,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static REGISTRY: OnceLock<PhaseRegistry> = OnceLock::new();
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("TGREP_PROFILE")
+            .ok()
+            .is_some_and(|value| value != "0" && !value.is_empty())
+    })
+}
+
+fn registry() -> &'static PhaseRegistry {
+    REGISTRY.get_or_init(PhaseRegistry::default)
+}
+
+pub fn time<T, F>(name: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let result = f();
+    let mut phases = registry().phases.lock().unwrap();
+    phases.entry(name).or_default().record(start.elapsed());
+    result
+}
+
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("tgrep phase timings:");
+    let phases = registry().phases.lock().unwrap();
+    for (name, stat) in phases.iter() {
+        eprintln!(
+            "  {name:<22} calls={:<8} total={:.3}s",
+            stat.calls,
+            stat.total.as_secs_f64()
+        );
+    }
+}

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -19,6 +19,7 @@ use crate::utils::lines::Zero;
 use crate::utils::mapped::Mapped;
 use crate::utils::matcher::Matcher;
 use crate::utils::patterns::{Patterns, ToPatterns};
+use crate::utils::timing;
 use crate::utils::writer::BufferedWriter;
 
 static GIT_IGNORE: &str = ".gitignore";
@@ -101,17 +102,19 @@ impl Walker {
     }
 
     fn is_excluded(&self, path: &Path, is_dir: bool) -> bool {
-        let path = path.to_str().unwrap();
-        let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping [forced] {:?}", path);
-            return true;
-        }
-        let skip = self.ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping {:?}", path);
-        }
-        skip
+        timing::time("walk.exclude", || {
+            let path = path.to_str().unwrap();
+            let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping [forced] {:?}", path);
+                return true;
+            }
+            let skip = self.ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping {:?}", path);
+            }
+            skip
+        })
     }
 
     fn process_gitignore(path: &Path) -> Option<Patterns> {
@@ -120,7 +123,7 @@ impl Walker {
             ifile.push(GIT_IGNORE);
             ifile
         };
-        match ifile.to_patterns() {
+        match timing::time("walk.gitignore", || ifile.to_patterns()) {
             Ok(ignore_patterns) => Some(ignore_patterns),
             Err(e) => {
                 match e.downcast_ref::<io::Error>() {
@@ -139,30 +142,48 @@ impl Walker {
     }
 
     fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
-        let walker = {
-            let mut walker = self.clone();
-            if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
-                ignore_patterns.extend(&walker.ignore_patterns);
-                walker.ignore_patterns = Arc::new(ignore_patterns);
-            }
-            walker
-        };
+        let mut walker = self.clone();
 
         let mut to_dive = Vec::new();
         let mut to_grep = Vec::new();
 
-        let mut entries: Vec<_> = fs::read_dir(path)
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| !self.is_ignore_file(entry))
-            .filter_map(|entry| match entry.file_type() {
-                Ok(file_type) => Some((entry.path(), file_type)),
-                Err(e) => {
-                    error!("Failed to get path '{}' file type: {}", path.display(), e);
-                    None
+        let entries: Vec<_> = timing::time("walk.read_dir", || {
+            fs::read_dir(path)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) => {
+                        let is_ignore_file = self.is_ignore_file(&entry);
+                        Some((entry.path(), file_type, is_ignore_file))
+                    }
+                    Err(e) => {
+                        error!("Failed to get path '{}' file type: {}", path.display(), e);
+                        None
+                    }
+                })
+                .collect()
+        });
+        if let Some(ignore_path) = entries
+            .iter()
+            .find_map(|(entry, _, is_ignore_file)| is_ignore_file.then_some(entry))
+        {
+            match timing::time("walk.gitignore", || ignore_path.to_patterns()) {
+                Ok(mut ignore_patterns) => {
+                    ignore_patterns.extend(&walker.ignore_patterns);
+                    walker.ignore_patterns = Arc::new(ignore_patterns);
                 }
-            })
-            .filter(|(entry, file_type)| !walker.is_excluded(entry, file_type.is_dir()))
+                Err(e) => error!(
+                    "Failed to process path '{}': {:?}",
+                    ignore_path.display(),
+                    e
+                ),
+            }
+        }
+        let mut entries: Vec<_> = entries
+            .into_iter()
+            .filter(|(_, _, is_ignore_file)| !is_ignore_file)
+            .filter(|(entry, file_type, _)| !walker.is_excluded(entry, file_type.is_dir()))
+            .map(|(entry, file_type, _)| (entry, file_type))
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
         for (path, file_type) in entries {


### PR DESCRIPTION
## Summary
This draft PR captures the walker-side `.gitignore` experiment.

It adds:
- opt-in phase profiling behind `TGREP_PROFILE=1`
- local `.gitignore` parsing from the directory entries already being scanned, instead of a separate `path/.gitignore` probe per directory

## Result
On the current large-tree no-match benchmark in this environment:
- before: `22.76s real`
- after: `21.97s real`

This is a measurable improvement from a walker-only change.

## What this experiment shows
- separate local `.gitignore` probes were real overhead
- folding `.gitignore` handling into the directory scan reduces walker cost without touching the grep path
- this is a cleaner signal than some of the earlier small-file experiments

## Notes
This PR is intended as an experiment checkpoint, not as the final optimization direction. Further work should continue from fresh branches for clean comparisons.