### PR TITLE
Experiment: combined walker and open path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use crate::utils::grep;
 use crate::utils::matcher::{Match, MatcherOptions};
 use crate::utils::patterns::Patterns;
 use crate::utils::stdin::Stdin;
+use crate::utils::timing;
 use crate::utils::walker::{Walker, WalkerBuilder, GIT_DIR};
 use crate::utils::writer::StdoutWriter;
 
@@ -320,6 +321,8 @@ fn main() -> Result<(), Error> {
             Arc::new(display),
         );
     }
+
+    timing::report();
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,5 +6,6 @@ pub mod mapped;
 pub mod matcher;
 pub mod patterns;
 pub mod stdin;
+pub mod timing;
 pub mod walker;
 pub mod writer;

--- a/src/utils/mapped.rs
+++ b/src/utils/mapped.rs
@@ -1,9 +1,4 @@
-use std::{
-    fs, ops,
-    path::{Path, PathBuf},
-    str,
-    sync::Arc,
-};
+use std::{fs::File, ops, path::PathBuf, str, sync::Arc};
 
 use log::debug;
 use memchr::memchr;
@@ -22,14 +17,10 @@ pub struct Mapped {
 }
 
 impl Mapped {
-    pub fn new(path: &Path, len: usize) -> anyhow::Result<Self> {
-        let file = fs::File::open(path)?;
+    pub fn from_file(path: PathBuf, file: File, len: usize) -> anyhow::Result<Self> {
         let mmap = unsafe { MmapOptions::new().len(len).map(&file)? };
         Ok(Mapped {
-            mapped: Arc::new(MappedInner {
-                path: path.to_owned(),
-                mmap,
-            }),
+            mapped: Arc::new(MappedInner { path, mmap }),
         })
     }
 }
@@ -123,7 +114,7 @@ impl StreamingIterator for MappedLines {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::fs::{self, File};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
@@ -158,7 +149,12 @@ mod tests {
     #[test]
     fn mapped_reader_returns_lines() {
         let file = TempFile::new(b"alpha\nbeta\ngamma");
-        let mapped = Mapped::new(file.path(), 16).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            16,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -170,7 +166,12 @@ mod tests {
     #[test]
     fn mapped_reader_trims_cr_before_lf() {
         let file = TempFile::new(b"alpha\r\nbeta\r\n");
-        let mapped = Mapped::new(file.path(), 13).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            13,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -181,7 +182,12 @@ mod tests {
     #[test]
     fn mapped_reader_falls_back_for_invalid_utf8() {
         let file = TempFile::new(b"ok\nf\x80o\n");
-        let mapped = Mapped::new(file.path(), 7).unwrap();
+        let mapped = Mapped::from_file(
+            file.path().to_path_buf(),
+            File::open(file.path()).unwrap(),
+            7,
+        )
+        .unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("ok"), lines.next());

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct PhaseStat {
+    calls: u64,
+    total: Duration,
+}
+
+impl PhaseStat {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls += 1;
+        self.total += elapsed;
+    }
+}
+
+#[derive(Default)]
+struct PhaseRegistry {
+    phases: Mutex<BTreeMap<&'static str, PhaseStat>>,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static REGISTRY: OnceLock<PhaseRegistry> = OnceLock::new();
+
+fn enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("TGREP_PROFILE")
+            .ok()
+            .is_some_and(|value| value != "0" && !value.is_empty())
+    })
+}
+
+fn registry() -> &'static PhaseRegistry {
+    REGISTRY.get_or_init(PhaseRegistry::default)
+}
+
+pub fn time<T, F>(name: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+    let start = Instant::now();
+    let result = f();
+    let mut phases = registry().phases.lock().unwrap();
+    phases.entry(name).or_default().record(start.elapsed());
+    result
+}
+
+pub fn report() {
+    if !enabled() {
+        return;
+    }
+    eprintln!("tgrep phase timings:");
+    let phases = registry().phases.lock().unwrap();
+    for (name, stat) in phases.iter() {
+        eprintln!(
+            "  {name:<22} calls={:<8} total={:.3}s",
+            stat.calls,
+            stat.total.as_secs_f64()
+        );
+    }
+}

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -3,7 +3,6 @@ use std::{
     fs::{self, DirEntry},
     io,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
 };
@@ -19,6 +18,7 @@ use crate::utils::lines::Zero;
 use crate::utils::mapped::Mapped;
 use crate::utils::matcher::Matcher;
 use crate::utils::patterns::{Patterns, ToPatterns};
+use crate::utils::timing;
 use crate::utils::writer::BufferedWriter;
 
 static GIT_IGNORE: &str = ".gitignore";
@@ -35,7 +35,7 @@ pub struct Walker {
     ignore_symlinks: bool,
     display: Arc<dyn Display>,
     print_file_separator: bool,
-    file_separator_printed: Rc<AtomicBool>,
+    file_separator_printed: Arc<AtomicBool>,
 }
 
 pub struct WalkerBuilder(Walker);
@@ -101,17 +101,19 @@ impl Walker {
     }
 
     fn is_excluded(&self, path: &Path, is_dir: bool) -> bool {
-        let path = path.to_str().unwrap();
-        let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping [forced] {:?}", path);
-            return true;
-        }
-        let skip = self.ignore_patterns.is_excluded(path, is_dir);
-        if skip {
-            info!("Skipping {:?}", path);
-        }
-        skip
+        timing::time("walk.exclude", || {
+            let path = path.to_str().unwrap();
+            let skip = self.force_ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping [forced] {:?}", path);
+                return true;
+            }
+            let skip = self.ignore_patterns.is_excluded(path, is_dir);
+            if skip {
+                info!("Skipping {:?}", path);
+            }
+            skip
+        })
     }
 
     fn process_gitignore(path: &Path) -> Option<Patterns> {
@@ -120,7 +122,7 @@ impl Walker {
             ifile.push(GIT_IGNORE);
             ifile
         };
-        match ifile.to_patterns() {
+        match timing::time("walk.gitignore", || ifile.to_patterns()) {
             Ok(ignore_patterns) => Some(ignore_patterns),
             Err(e) => {
                 match e.downcast_ref::<io::Error>() {
@@ -139,30 +141,48 @@ impl Walker {
     }
 
     fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
-        let walker = {
-            let mut walker = self.clone();
-            if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
-                ignore_patterns.extend(&walker.ignore_patterns);
-                walker.ignore_patterns = Arc::new(ignore_patterns);
-            }
-            walker
-        };
+        let mut walker = self.clone();
 
         let mut to_dive = Vec::new();
         let mut to_grep = Vec::new();
 
-        let mut entries: Vec<_> = fs::read_dir(path)
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| !self.is_ignore_file(entry))
-            .filter_map(|entry| match entry.file_type() {
-                Ok(file_type) => Some((entry.path(), file_type)),
-                Err(e) => {
-                    error!("Failed to get path '{}' file type: {}", path.display(), e);
-                    None
+        let entries: Vec<_> = timing::time("walk.read_dir", || {
+            fs::read_dir(path)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) => {
+                        let is_ignore_file = self.is_ignore_file(&entry);
+                        Some((entry.path(), file_type, is_ignore_file))
+                    }
+                    Err(e) => {
+                        error!("Failed to get path '{}' file type: {}", path.display(), e);
+                        None
+                    }
+                })
+                .collect()
+        });
+        if let Some(ignore_path) = entries
+            .iter()
+            .find_map(|(entry, _, is_ignore_file)| is_ignore_file.then_some(entry))
+        {
+            match timing::time("walk.gitignore", || ignore_path.to_patterns()) {
+                Ok(mut ignore_patterns) => {
+                    ignore_patterns.extend(&walker.ignore_patterns);
+                    walker.ignore_patterns = Arc::new(ignore_patterns);
                 }
-            })
-            .filter(|(entry, file_type)| !walker.is_excluded(entry, file_type.is_dir()))
+                Err(e) => error!(
+                    "Failed to process path '{}': {:?}",
+                    ignore_path.display(),
+                    e
+                ),
+            }
+        }
+        let mut entries: Vec<_> = entries
+            .into_iter()
+            .filter(|(_, _, is_ignore_file)| !is_ignore_file)
+            .filter(|(entry, file_type, _)| !walker.is_excluded(entry, file_type.is_dir()))
+            .map(|(entry, file_type, _)| (entry, file_type))
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
         for (path, file_type) in entries {
@@ -189,24 +209,43 @@ impl Walker {
     }
 
     fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
-        let len = fs::metadata(entry.as_path())
-            .ok()
-            .map(|meta| meta.len() as usize);
-        if matches!(len, Some(0)) {
-            (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
+        let file = match timing::time("file.open", || fs::File::open(entry.as_path())) {
+            Ok(file) => file,
+            Err(e) => {
+                warn!("Failed to open file '{}': {}", entry.display(), e);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
+                return;
+            }
+        };
+        let len = match timing::time("file.metadata", || file.metadata()) {
+            Ok(meta) => meta.len() as usize,
+            Err(e) => {
+                warn!("Failed to get file metadata '{}': {}", entry.display(), e);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
+                return;
+            }
+        };
+        if len == 0 {
+            timing::time("grep.total", || {
+                (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display)
+            });
             return;
         }
-        match len.and_then(|len| Mapped::new(&entry, len).ok()) {
+        match timing::time("file.mmap", || {
+            Mapped::from_file((*entry).clone(), file, len).ok()
+        }) {
             Some(mapped) => {
-                if content_inspector::inspect(&mapped).is_binary() {
+                if timing::time("file.inspect_binary", || {
+                    content_inspector::inspect(&mapped).is_binary()
+                }) {
                     debug!("Skipping binary file '{}'", entry.display());
                     return;
                 }
-                (grep)(Arc::new(mapped), matcher, display);
+                timing::time("grep.total", || (grep)(Arc::new(mapped), matcher, display));
             }
             None => {
                 warn!("Failed to map file '{}'", entry.display());
-                (grep)(entry, matcher, display);
+                timing::time("grep.total", || (grep)(entry, matcher, display));
             }
         }
     }


### PR DESCRIPTION
## Summary
This draft PR captures the combined experiment from the two best prior signals:
- walker-side `.gitignore` handling from the directory scan
- file open path that removes the separate metadata probe and reuses the same open handle for `mmap`

## Result
On the current large-tree no-match benchmark in this environment:
- before: `23.42s real`
- after: `22.19s real`

This is the strongest improvement so far among the isolated experiment branches.

## What this experiment shows
- eliminating separate local `.gitignore` probes helps
- eliminating the standalone `metadata()` pass helps
- the remaining dominant costs are now file open, binary inspection, and mapping/setup work

## Notes
This PR is intended as an experiment checkpoint, not necessarily the final merge candidate. It is the clearest positive result so far and likely the best base for any follow-up work.