### PR TITLE
Note: search architecture redesign

### DIFF
--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -229,6 +229,27 @@ Target runtime flow:
 
 ## Migration Plan
 
+### Prototype Findings
+
+The first direct classify-layer prototype was attempted on top of the plain post-PR-19 baseline.
+
+Result:
+
+- it regressed badly on the no-match large-tree workload
+- the main issue was adding extra per-file prefix I/O before removing enough of the old heavy path
+
+Implication:
+
+- a classify layer is still the right long-term direction
+- but it must be introduced on top of a better file-processing base, not layered naively over the original `metadata -> map -> inspect -> grep` flow
+
+Revised guidance:
+
+- start future classify-layer work from the stronger combined branch shape
+- specifically, build it on top of the branch that already:
+  - removes the standalone `metadata()` probe
+  - folds local `.gitignore` handling into directory scans
+
 ### Phase 1
 
 Introduce explicit `FileTask` and `SearchResult` types without changing behavior much.
@@ -310,7 +331,7 @@ Stop pursuing isolated local micro-optimizations as the main strategy.
 Use the current best-performing branch as a reference point, then start a staged redesign with:
 
 1. walker replacement
-2. classify layer
+2. classify layer on top of the stronger combined file path, not the original baseline
 3. split search engines
 4. ordered result buffering
 

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -11,12 +11,27 @@ The strongest clean-branch result so far combined:
 
 That improved a representative no-match large-tree workload from roughly `23.42s` to roughly `22.19s`.
 
-The conclusion is that local tuning has mostly reached diminishing returns. The remaining cost is dominated by the core per-file processing pipeline:
+### Benchmark Baseline (2026-03-27)
+
+A fresh benchmark on the post-PR-19 codebase against a large monorepo subtree (~hundreds of thousands of files) with pattern `foooxxxyyy` (no matches, exercises traversal + open + fuzzy-reject hot path):
+
+| Tool  | Wall time | User  | System  |
+|-------|-----------|-------|---------|
+| tgrep | 13.92s    | 2.62s | 37.97s  |
+| rg    | 9.09s     | 1.34s | 91.39s  |
+
+Key takeaway: `rg` is ~1.5x faster wall-clock despite using ~2.4x more total system time. This means `rg` wins almost entirely through **parallelism** — it issues far more concurrent syscalls across threads. `tgrep`'s user-space time is already low; the bottleneck is sequential syscall throughput, not CPU work.
+
+### Conclusion
+
+Local tuning has mostly reached diminishing returns. The remaining cost is dominated by the core per-file processing pipeline:
 
 - open file
 - classify text vs binary
 - read or map file contents
 - search contents
+
+And critically, by the **sequential traversal of directories**, which serializes the syscall-heavy pipeline.
 
 This note proposes a structural redesign for that pipeline.
 
@@ -24,7 +39,7 @@ This note proposes a structural redesign for that pipeline.
 
 ### 1. Traversal, classification, search, and output are tightly coupled
 
-In the current code, [src/utils/walker.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/utils/walker.rs) is responsible for:
+In the current code, `src/utils/walker.rs` is responsible for:
 
 - recursive traversal
 - `.gitignore` handling
@@ -55,6 +70,26 @@ Line extraction is appropriate for rendering results, but it is not the best pri
 ### 4. Sorted output constrains concurrency
 
 The current design keeps output deterministic, but traversal and execution are not cleanly separated from ordering. That limits opportunities for deeper parallelism.
+
+### 5. Double stat per file
+
+`walk_dir` calls `entry.file_type()` on each directory entry, then `grep()` calls `fs::metadata()` again on the same path to obtain the file size for `mmap`. On macOS, `file_type()` reads from the dirent structure (no extra syscall), but `metadata()` is a full `stat()`. Since `Mapped::new` could let `mmap` auto-detect the file size from the fd's `fstat` (issued internally by the kernel during `mmap`), the explicit `metadata()` call is redundant.
+
+### 6. Sequential directory traversal
+
+`walk_dir` processes subdirectories in a sequential loop. Only files within a single directory are parallelized via `grep_many`. The benchmark confirms this: `rg` achieves 91s of system time (many concurrent syscalls across threads) vs `tgrep`'s 38s. The wall-clock gap is almost entirely explained by this difference in traversal parallelism.
+
+### 7. Walker clone and gitignore probe on every directory
+
+`walk_dir` clones the `Walker` struct and attempts to open `.gitignore` on every directory entry, even when no `.gitignore` exists. The clone itself is cheap (Arc reference bumps), but the failed file open is a wasted syscall per directory.
+
+### 8. Regex engine used for literal fuzzy pre-check
+
+`fuzzy_grep` calls `regexp.shortest_match(map)` to pre-filter files before line iteration. For a literal pattern like `foooxxxyyy`, this runs the full regex engine over the entire mmap'd content. A `memmem`-based literal search (already available in `patterns.rs` via libc FFI) would be faster for this common case.
+
+### 9. No release profile tuning
+
+`Cargo.toml` has no `[profile.release]` section. The default release profile uses incremental LTO and 16 codegen units. Adding `lto = true` and `codegen-units = 1` can yield measurable improvements with zero code changes.
 
 ## Decision
 
@@ -227,6 +262,44 @@ Target runtime flow:
 5. results are buffered by sequence number
 6. renderer flushes in deterministic order
 
+## Pre-Redesign Optimizations
+
+Before committing to the full staged redesign, several targeted fixes can reduce the gap with `rg` within the existing architecture. These are worth doing first because they are low-risk, independently valuable, and inform whether the full redesign is necessary.
+
+### O1. Release profile tuning
+
+Add to `Cargo.toml`:
+
+```toml
+[profile.release]
+lto = true
+codegen-units = 1
+```
+
+Expected impact: small but free. Tighter inlining across crate boundaries, especially for the `memchr`, `regex`, and `content_inspector` hot paths.
+
+### O2. Eliminate redundant metadata syscall
+
+Remove the `fs::metadata()` call in `Walker::grep()`. Instead of passing a pre-computed `len` to `Mapped::new`, let `MmapOptions` derive the file size from the fd (which it does internally via `fstat` when no explicit length is set). This eliminates one `stat()` per file.
+
+### O3. Skip Walker clone when no .gitignore
+
+In `walk_dir`, check for `.gitignore` existence before cloning the walker. When no `.gitignore` is found (the common case in deep subtrees), reuse `self` directly instead of cloning and re-wrapping `ignore_patterns` in a new `Arc`.
+
+### O4. Parallel directory traversal
+
+Submit subdirectory walks to the thread pool instead of processing them sequentially. This is the single highest-impact change available within the current architecture — the benchmark data shows the wall-clock gap with `rg` is almost entirely due to traversal parallelism.
+
+This requires care around output ordering (the current `grep_many` + `BufferedWriter` flush model assumes a single directory's files are processed together), but a sequence-number approach can be introduced incrementally.
+
+### O5. Literal pre-filter bypass
+
+When the pattern compiles to a pure literal (no regex metacharacters), use `memmem` (already available via libc FFI in `patterns.rs`) instead of `regexp.shortest_match()` for the fuzzy pre-check in `generic_grep`. This avoids regex engine overhead on the most common case for the no-match workload.
+
+### O6. Avoid parents Vec reallocation
+
+Replace the `parents.to_owned()` + push pattern in `walk_dir` with a stack-like structure or pass a reference to a shared growable buffer, avoiding a full `Vec<PathBuf>` clone at every directory level.
+
 ## Migration Plan
 
 ### Prototype Findings
@@ -327,13 +400,15 @@ Not rejected in principle, but too large and risky as a single change. Increment
 
 ## Recommendation
 
-Stop pursuing isolated local micro-optimizations as the main strategy.
+Two-track approach:
 
-Use the current best-performing branch as a reference point, then start a staged redesign with:
+**Track 1 — targeted fixes (O1–O6):** Apply the pre-redesign optimizations first. These are low-risk, independently benchmarkable, and may close a meaningful portion of the gap with `rg`. In particular, O4 (parallel directory traversal) addresses the dominant bottleneck identified by the system-time analysis.
 
-1. walker replacement
-2. classify layer on top of the stronger combined file path, not the original baseline
-3. split search engines
-4. ordered result buffering
+**Track 2 — staged redesign:** If Track 1 leaves a significant gap, proceed with the full architectural migration:
 
-That is the most credible path to a materially faster `tgrep`.
+1. walker replacement (`ignore::WalkBuilder`)
+2. classify layer on top of the stronger combined file path
+3. split literal and regex search engines
+4. ordered result buffering by sequence id
+
+Track 1 results will also inform Track 2 priorities — if parallel traversal alone closes most of the gap, the classify layer becomes less urgent than the search engine split.

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -87,9 +87,11 @@ The current design keeps output deterministic, but traversal and execution are n
 
 `fuzzy_grep` calls `regexp.shortest_match(map)` to pre-filter files before line iteration. For a literal pattern like `foooxxxyyy`, this runs the full regex engine over the entire mmap'd content. A `memmem`-based literal search (already available in `patterns.rs` via libc FFI) would be faster for this common case.
 
-### 9. No release profile tuning
+### 9. Remaining wins are structural, not profile-level
 
-`Cargo.toml` has no `[profile.release]` section. The default release profile uses incremental LTO and 16 codegen units. Adding `lto = true` and `codegen-units = 1` can yield measurable improvements with zero code changes.
+`Cargo.toml` already enables `lto = true` and `codegen-units = 1` in `[profile.release]`.
+
+That matters because it removes one obvious "free win" from the table: the remaining gap to `rg` is no longer plausibly explained by missing release-profile tuning. The remaining work is architectural: traversal parallelism, search-path specialization, and reducing unnecessary per-file setup.
 
 ## Decision
 
@@ -125,12 +127,14 @@ Recommended direction:
 - replace the custom recursive walker with `ignore::WalkBuilder`
 - assign a stable sequence number to every discovered file
 - emit `FileTask { seq, path }`
+- preserve current symlink behavior explicitly rather than assuming `follow_links(true)` is a drop-in replacement
 
 Why:
 
 - this aligns the traversal layer with the same family of tooling used by `rg`
 - it removes a large amount of custom ignore and recursion logic
 - it makes later parallelism easier
+- it keeps ordering semantics separate from execution semantics, which is required for safe parallelism
 
 ### 2. Classify Layer
 
@@ -165,6 +169,7 @@ Key design rule:
 
 - classification must be cheap
 - classification must reuse the same open handle or already-read bytes where possible
+- classification is an optimization stage, not a rendering stage; regex/context modes may still need a full downstream path
 
 This is the main architectural change that the experiments point toward.
 
@@ -210,6 +215,11 @@ This gives:
 - more freedom for parallel traversal and search
 - cleaner separation between execution and user-visible ordering
 
+Important constraint:
+
+- `seq` must represent compatibility order, not convenience order
+- global path-sort is not an equivalent replacement for today's behavior when multiple roots or symlinked trees are involved
+
 ### 5. Render Layer
 
 Responsibility:
@@ -246,6 +256,17 @@ One possible shape:
   - current display-oriented code can migrate here over time
 
 This does not need to happen in one rewrite, but it should be the target shape.
+
+## Compatibility Constraints
+
+Any redesign should preserve these user-visible behaviors unless the project explicitly chooses to change them:
+
+- multiple input roots are processed in CLI argument order
+- output remains deterministic under parallel execution
+- symlink traversal keeps the current loop and ancestor-duplication protections
+- `-e`, `-f`, `-t`, parent `.gitignore`, and explicit file arguments continue to compose correctly
+
+Those constraints should shape the implementation plan. They are not follow-up polish.
 
 ## Execution Flow
 

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -1,0 +1,317 @@
+# Search Architecture Redesign
+
+## Context
+
+Recent performance experiments improved `tgrep`, but only incrementally.
+
+The strongest clean-branch result so far combined:
+
+- walker-side `.gitignore` handling from directory scans
+- removal of the standalone `metadata()` pass before `mmap`
+
+That improved a representative no-match large-tree workload from roughly `23.42s` to roughly `22.19s`.
+
+The conclusion is that local tuning has mostly reached diminishing returns. The remaining cost is dominated by the core per-file processing pipeline:
+
+- open file
+- classify text vs binary
+- read or map file contents
+- search contents
+
+This note proposes a structural redesign for that pipeline.
+
+## Current Problems
+
+### 1. Traversal, classification, search, and output are tightly coupled
+
+In the current code, [src/utils/walker.rs](/Users/dmytro.milinevskyi/dev/tgrep/src/utils/walker.rs) is responsible for:
+
+- recursive traversal
+- `.gitignore` handling
+- symlink handling
+- file classification decisions
+- launching grep work
+- partial output-order coordination
+
+That makes local tuning possible, but it makes larger performance improvements harder because one stage cannot evolve independently of the others.
+
+### 2. Every file pays too much setup cost
+
+The current path is effectively:
+
+1. find file
+2. fetch metadata
+3. open or map file
+4. classify binary vs text
+5. run grep
+6. render output
+
+For a large tree with mostly non-matches, this means the expensive parts are paid before there is strong evidence that the file is worth fully processing.
+
+### 3. The search path is too line-oriented too early
+
+Line extraction is appropriate for rendering results, but it is not the best primitive for deciding whether a file should be fully searched in the first place.
+
+### 4. Sorted output constrains concurrency
+
+The current design keeps output deterministic, but traversal and execution are not cleanly separated from ordering. That limits opportunities for deeper parallelism.
+
+## Decision
+
+Adopt a staged search architecture with explicit subsystem boundaries:
+
+1. `Walk`
+2. `Classify`
+3. `Search`
+4. `Order`
+5. `Render`
+
+The high-level goal is:
+
+- traverse quickly
+- classify files cheaply
+- fully search only likely candidates
+- preserve deterministic output ordering
+
+## Proposed Architecture
+
+### 1. Walk Layer
+
+Responsibility:
+
+- recursive traversal
+- ignore handling
+- symlink policy
+- file discovery
+- stable file sequencing
+
+Recommended direction:
+
+- replace the custom recursive walker with `ignore::WalkBuilder`
+- assign a stable sequence number to every discovered file
+- emit `FileTask { seq, path }`
+
+Why:
+
+- this aligns the traversal layer with the same family of tooling used by `rg`
+- it removes a large amount of custom ignore and recursion logic
+- it makes later parallelism easier
+
+### 2. Classify Layer
+
+Responsibility:
+
+- open file once
+- read a small prefix
+- quickly determine:
+  - empty file
+  - likely binary
+  - likely text
+  - plain-literal impossible match
+  - needs full search
+
+Proposed interface:
+
+```rust
+struct FileTask {
+    seq: u64,
+    path: PathBuf,
+}
+
+enum FileDecision {
+    Skip,
+    EmptyText,
+    PrefixText(PrefixBuffer),
+    NeedsFullSearch(FileHandleState),
+}
+```
+
+Key design rule:
+
+- classification must be cheap
+- classification must reuse the same open handle or already-read bytes where possible
+
+This is the main architectural change that the experiments point toward.
+
+### 3. Search Layer
+
+Responsibility:
+
+- execute the actual search strategy chosen for the file
+
+This should split by query shape:
+
+- `LiteralSearchEngine`
+- `RegexSearchEngine`
+
+And by file state:
+
+- search from prefix-buffered content when enough data is already loaded
+- search from a full in-memory buffer for small files
+- search from `mmap` or stream for larger files
+
+Important principle:
+
+- do not default every search to the same path
+
+A plain literal and a full regex with context should not pay the same setup cost.
+
+### 4. Order Layer
+
+Responsibility:
+
+- preserve deterministic output ordering independent of execution order
+
+Proposed model:
+
+- walker assigns `seq`
+- workers search files in parallel
+- results are emitted as `SearchResult { seq, payload }`
+- an order coordinator flushes results strictly in `seq` order
+
+This gives:
+
+- deterministic output
+- more freedom for parallel traversal and search
+- cleaner separation between execution and user-visible ordering
+
+### 5. Render Layer
+
+Responsibility:
+
+- turn matches into user-visible output
+
+This should remain line-oriented, but only after the search layer has decided the file actually contains something worth rendering.
+
+That means:
+
+- byte-oriented or buffer-oriented search first
+- line formatting second
+
+## Proposed Module Split
+
+One possible shape:
+
+- `src/walk/`
+  - `mod.rs`
+  - `task.rs`
+  - `ignore.rs`
+- `src/classify/`
+  - `mod.rs`
+  - `prefix.rs`
+  - `binary.rs`
+- `src/search/`
+  - `mod.rs`
+  - `literal.rs`
+  - `regex.rs`
+- `src/order/`
+  - `mod.rs`
+  - `buffer.rs`
+- `src/render/`
+  - current display-oriented code can migrate here over time
+
+This does not need to happen in one rewrite, but it should be the target shape.
+
+## Execution Flow
+
+Target runtime flow:
+
+1. walk emits `FileTask`
+2. classify opens file once and reads a small prefix
+3. classify decides:
+   - skip
+   - emit empty result
+   - search buffered content directly
+   - continue with full search path
+4. search engine runs in parallel
+5. results are buffered by sequence number
+6. renderer flushes in deterministic order
+
+## Migration Plan
+
+### Phase 1
+
+Introduce explicit `FileTask` and `SearchResult` types without changing behavior much.
+
+Goal:
+
+- separate traversal identity from rendering identity
+
+### Phase 2
+
+Replace the custom walker with `ignore::WalkBuilder`, but keep the current grep path.
+
+Goal:
+
+- modernize traversal and ignore handling first
+
+### Phase 3
+
+Add a real classify layer:
+
+- open once
+- prefix read
+- cheap binary detection
+- literal prefilter when applicable
+
+Goal:
+
+- make early skips materially cheaper than full search
+
+### Phase 4
+
+Split literal and regex search engines.
+
+Goal:
+
+- stop forcing all query types through the same pipeline
+
+### Phase 5
+
+Add ordered result buffering by sequence id.
+
+Goal:
+
+- unlock more parallelism while preserving sorted output
+
+## Alternatives Considered
+
+### Continue micro-optimizing the current design
+
+Rejected because the experiment branches showed only modest gains. The remaining bottleneck is structural.
+
+### Give up deterministic ordering
+
+Rejected because deterministic output appears to be a real project requirement.
+
+### Switch directly to a complete ripgrep-like architecture in one step
+
+Not rejected in principle, but too large and risky as a single change. Incremental migration is safer.
+
+## Consequences
+
+### Positive
+
+- better alignment with the actual bottlenecks
+- cleaner subsystem boundaries
+- more room for meaningful parallelism
+- easier future experimentation with search engines and file strategies
+
+### Negative
+
+- more code motion
+- higher implementation complexity
+- temporary coexistence of old and new paths during migration
+
+## Recommendation
+
+Stop pursuing isolated local micro-optimizations as the main strategy.
+
+Use the current best-performing branch as a reference point, then start a staged redesign with:
+
+1. walker replacement
+2. classify layer
+3. split search engines
+4. ordered result buffering
+
+That is the most credible path to a materially faster `tgrep`.

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -410,17 +410,35 @@ Not rejected in principle, but too large and risky as a single change. Increment
 - higher implementation complexity
 - temporary coexistence of old and new paths during migration
 
+## Experiment Results
+
+### Track 1 (O1–O6)
+
+All Track 1 optimizations were implemented and benchmarked. A/B testing with hyperfine against the pre-optimization baseline (same cache state, same machine) showed:
+
+| Variant | Wall time | User | System |
+|---------|-----------|------|--------|
+| Baseline (pre-O1) | 14.22s | 2.68s | 31.32s |
+| O1–O3 | 14.22s | 2.46s | 34.62s |
+| O1–O3+O5+O6 | 14.52s | 2.45s | 29.25s |
+
+O1–O3 reduce user-space CPU time by ~8% (LTO + fewer syscalls + fewer clones), but wall time is unchanged because this workload is I/O-bound. O5 (literal pre-filter) provides no benefit — the regex engine already uses literal optimizations internally. O6 (parents Vec reallocation) is negligible.
+
+O4 (parallel directory traversal) regressed wall time when attempted via `std::thread::scope` (see above).
+
+Earlier measurements showing ~14% improvement from O1–O3 were artifacts of filesystem cache warming, not code changes.
+
+### Conclusion
+
+O1–O3 are kept as code quality improvements (cleaner APIs, less redundant work, better release builds) but they do not close the gap with `rg` on this I/O-bound workload. O5–O6 are dropped as they add complexity without measurable benefit.
+
 ## Recommendation
 
-Two-track approach:
+The gap with `rg` (~14s vs ~9s) is entirely structural and requires the Track 2 architectural migration:
 
-**Track 1 — targeted fixes (O1–O3, O5–O6):** O1 (release profile), O2 (eliminate redundant stat), and O3 (skip walker clone) are implemented and reduce wall time from 13.92s to 11.93s (~14% improvement). O5 (literal pre-filter) and O6 (parents Vec) remain as further incremental opportunities.
-
-O4 (parallel directory traversal) was attempted and confirmed to require structural redesign — it cannot be effectively bolted onto the current recursive `walk_dir` architecture.
-
-**Track 2 — staged redesign:** The remaining ~30% gap with `rg` (11.93s vs 9.09s) requires the full architectural migration:
-
-1. walker replacement (`ignore::WalkBuilder`) — this is now the clear first priority, as it provides parallel traversal via a producer-consumer design rather than recursive thread spawning
+1. walker replacement (`ignore::WalkBuilder`) — this is the clear first priority, as it provides parallel traversal via a producer-consumer design rather than recursive thread spawning
 2. classify layer on top of the stronger combined file path
 3. split literal and regex search engines
 4. ordered result buffering by sequence id
+
+Track 1 micro-optimizations have been exhausted. No further local tuning can close the gap.

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -242,6 +242,7 @@ Implication:
 
 - a classify layer is still the right long-term direction
 - but it must be introduced on top of a better file-processing base, not layered naively over the original `metadata -> map -> inspect -> grep` flow
+- for a repository that is mostly text, prefix-only classification is not a strong standalone optimization unless it replaces enough downstream work
 
 Revised guidance:
 

--- a/ARCHITECTURE_SEARCH_REDESIGN.md
+++ b/ARCHITECTURE_SEARCH_REDESIGN.md
@@ -286,11 +286,23 @@ Remove the `fs::metadata()` call in `Walker::grep()`. Instead of passing a pre-c
 
 In `walk_dir`, check for `.gitignore` existence before cloning the walker. When no `.gitignore` is found (the common case in deep subtrees), reuse `self` directly instead of cloning and re-wrapping `ignore_patterns` in a new `Arc`.
 
-### O4. Parallel directory traversal
+### O4. Parallel directory traversal — requires structural redesign
 
-Submit subdirectory walks to the thread pool instead of processing them sequentially. This is the single highest-impact change available within the current architecture — the benchmark data shows the wall-clock gap with `rg` is almost entirely due to traversal parallelism.
+Attempted: parallelize subdirectory walks using `std::thread::scope` with a depth limit, buffering each subtree's output in a `BufferedWriter` and flushing in sorted order.
 
-This requires care around output ordering (the current `grep_many` + `BufferedWriter` flush model assumes a single directory's files are processed together), but a sequence-number approach can be introduced incrementally.
+Results (no-match large-tree workload, on top of O1–O3 baseline of 11.93s):
+
+| Approach | Wall time | User | System |
+|----------|-----------|------|--------|
+| O1–O3 (sequential walk) | 11.93s | 2.47s | 45.19s |
+| O4 depth=3 | 14.16s | 3.26s | 31.44s |
+| O4 depth=1 | 13.07s | 2.69s | 29.21s |
+
+Both parallel walk variants regressed wall time despite reducing total system time. The root cause is that `std::thread::scope` imposes synchronization barriers at each directory level — the parent must wait for ALL children before continuing. This limits effective parallelism and adds OS thread creation/joining overhead that outweighs the benefit.
+
+Additionally, the `futures::executor::ThreadPool` cannot be used for recursive directory spawning (causes thread pool starvation deadlock), forcing the use of OS threads.
+
+Conclusion: parallel directory traversal cannot be bolt-on to the current recursive `walk_dir` architecture. It requires a producer-consumer design where the walk emits file paths into a shared work queue and independent worker threads consume them — which is the Track 2 redesign (specifically, `ignore::WalkBuilder::build_parallel()` or equivalent).
 
 ### O5. Literal pre-filter bypass
 
@@ -402,13 +414,13 @@ Not rejected in principle, but too large and risky as a single change. Increment
 
 Two-track approach:
 
-**Track 1 — targeted fixes (O1–O6):** Apply the pre-redesign optimizations first. These are low-risk, independently benchmarkable, and may close a meaningful portion of the gap with `rg`. In particular, O4 (parallel directory traversal) addresses the dominant bottleneck identified by the system-time analysis.
+**Track 1 — targeted fixes (O1–O3, O5–O6):** O1 (release profile), O2 (eliminate redundant stat), and O3 (skip walker clone) are implemented and reduce wall time from 13.92s to 11.93s (~14% improvement). O5 (literal pre-filter) and O6 (parents Vec) remain as further incremental opportunities.
 
-**Track 2 — staged redesign:** If Track 1 leaves a significant gap, proceed with the full architectural migration:
+O4 (parallel directory traversal) was attempted and confirmed to require structural redesign — it cannot be effectively bolted onto the current recursive `walk_dir` architecture.
 
-1. walker replacement (`ignore::WalkBuilder`)
+**Track 2 — staged redesign:** The remaining ~30% gap with `rg` (11.93s vs 9.09s) requires the full architectural migration:
+
+1. walker replacement (`ignore::WalkBuilder`) — this is now the clear first priority, as it provides parallel traversal via a producer-consumer design rather than recursive thread spawning
 2. classify layer on top of the stronger combined file path
 3. split literal and regex search engines
 4. ordered result buffering by sequence id
-
-Track 1 results will also inform Track 2 priorities — if parallel traversal alone closes most of the gap, the classify layer becomes less urgent than the search engine split.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ harness = false
 [dev-dependencies]
 criterion = "0.8"
 
+[profile.release]
+lto = true
+codegen-units = 1
+
 [dependencies]
 log = "0.4.29"
 env_logger = "0.11"

--- a/IMPL_PARALLEL_WALKER.md
+++ b/IMPL_PARALLEL_WALKER.md
@@ -1,0 +1,208 @@
+# Implementation Plan: Replace custom walker with `ignore::WalkBuilder::build_parallel()`
+
+## Context
+
+Benchmarks show tgrep at ~14s vs rg at ~9s on a large monorepo no-match workload. A/B testing confirmed the gap is entirely structural — the custom sequential recursive walker in `walker.rs` (362 lines) plus the hand-rolled .gitignore parser in `patterns.rs` (514 lines) cannot match the parallel traversal of the `ignore` crate (same crate rg uses). All Track 1 micro-optimizations have been exhausted.
+
+## Approach: parallel walk with collect-and-sort ordering
+
+Replace the recursive `Walker` with `ignore::WalkBuilder::build_parallel()`. The parallel walker dispatches files to worker threads. Each thread greps the file and buffers output. After the walk completes, results are sorted by path and flushed to stdout — preserving deterministic output.
+
+The `futures::executor::ThreadPool` is removed — `ignore`'s parallel walker already provides file-level parallelism, making the separate pool redundant.
+
+## Files to modify
+
+| File | Action |
+|------|--------|
+| `Cargo.toml` | Add `ignore = "0.4"`, remove `futures`, `crossbeam` |
+| `src/utils.rs` | Remove `walker`, `filters`, add `parallel_walker` |
+| `src/utils/parallel_walker.rs` | **New** — parallel walk + collect-and-sort output |
+| `src/main.rs` | Rewire to use `ParallelWalker`, translate filters/ignore to `ignore` overrides |
+| `src/utils/walker.rs` | **Delete** |
+| `src/utils/filters.rs` | **Delete** |
+| `src/utils/grep.rs` | Extract `grep_file` from `Walker::grep` (open, mmap, binary check, dispatch) |
+| `src/utils/writer.rs` | Add `BufferedWriter::take` method |
+| `src/utils/display.rs` | Keep as-is — `with_writer()` used for per-file buffered display |
+| `src/utils/patterns.rs` | Keep for now — still used by `benches/patterns.rs` |
+| `tests/cli.rs` | Add integration tests covering subdirectory walks |
+
+## Implementation steps
+
+### Step 1: Add `ignore` dep, extract `grep_file`
+
+Add `ignore = "0.4"` to `Cargo.toml`.
+
+Move `Walker::grep` logic into a standalone function in `grep.rs`:
+
+```rust
+pub fn grep_file(grep: &Grep, path: &Path, matcher: &Matcher, display: &Arc<dyn Display>) {
+    match Mapped::open(path) {
+        Ok(Some(mapped)) => {
+            if content_inspector::inspect(&mapped).is_binary() { return; }
+            (grep)(Arc::new(mapped), matcher.clone(), display.clone());
+        }
+        Ok(None) => {
+            (grep)(Arc::new(Zero::new(path.to_path_buf())), matcher.clone(), display.clone());
+        }
+        Err(_) => {
+            (grep)(Arc::new(path.to_path_buf()), matcher.clone(), display.clone());
+        }
+    }
+}
+```
+
+This is a refactor with no behavior change — existing `Walker::grep` calls delegate to it.
+
+### Step 2: Implement `parallel_walker.rs`
+
+Core structure:
+
+```rust
+struct FileResult {
+    path: PathBuf,
+    output: Vec<String>,
+}
+
+pub fn parallel_walk(
+    paths: &[PathBuf],
+    grep: Grep,
+    matcher: Matcher,
+    display: Arc<dyn Display>,
+    overrides: Override,        // replaces force_ignore + file_filters
+    follow_links: bool,        // replaces !ignore_symlinks
+    print_file_separator: bool,
+) {
+    let results: Arc<Mutex<Vec<FileResult>>> = Arc::new(Mutex::new(Vec::new()));
+
+    for fpath in paths {
+        let walker = WalkBuilder::new(fpath)
+            .hidden(false)         // tgrep does NOT skip dotfiles
+            .parents(true)         // honor parent .gitignore files
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .follow_links(follow_links)
+            .overrides(overrides.clone())
+            .build_parallel();
+
+        walker.run(|| {
+            // Per-thread closure — captures clones of grep, matcher, display, results
+            let grep = grep.clone();
+            let matcher = matcher.clone();
+            let display = display.clone();
+            let results = results.clone();
+            Box::new(move |entry| {
+                let entry = match entry { Ok(e) => e, Err(_) => return WalkState::Continue };
+                if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+                    return WalkState::Continue;
+                }
+                let path = entry.into_path();
+                let writer = Arc::new(BufferedWriter::new());
+                let file_display = display.with_writer(writer.clone());
+                grep_file(&grep, &path, &matcher, &file_display);
+                if writer.has_some() {
+                    results.lock().unwrap().push(FileResult {
+                        path,
+                        output: writer.take(),
+                    });
+                }
+                WalkState::Continue
+            })
+        });
+    }
+
+    // Sort and flush
+    let mut results = Arc::try_unwrap(results).unwrap().into_inner().unwrap();
+    results.sort_by(|a, b| a.path.cmp(&b.path));
+    let writer = display.writer();
+    for (i, result) in results.iter().enumerate() {
+        if print_file_separator && i > 0 { display.file_separator(); }
+        for line in &result.output {
+            writer.write(line);
+        }
+    }
+}
+```
+
+### Step 3: Translate filter/ignore patterns to `ignore::overrides`
+
+In `main.rs`, build `Override` from existing CLI args:
+
+```rust
+let mut override_builder = OverrideBuilder::new(&fpath);
+// force_ignore_patterns -> negated overrides
+for pattern in &args.force_ignore_patterns {
+    override_builder.add(&format!("!{}", pattern))?;
+}
+// file_filters -> whitelist overrides (only if user specified filters)
+if !filter_patterns.iter().all(|p| p == "*") {
+    for pattern in &filter_patterns {
+        override_builder.add(pattern)?;
+    }
+}
+let overrides = override_builder.build()?;
+```
+
+`.git/` force-ignore is unnecessary — `ignore` crate handles it natively.
+
+### Step 4: Update `main.rs` wiring
+
+Replace the `for path in paths` loop body:
+
+- Remove `Walker::find_ignore_patterns_in_parents` (handled by `WalkBuilder::parents(true)`)
+- Remove `Patterns::new` and `Filters::new` (replaced by overrides)
+- Remove `WalkerBuilder` construction
+- Call `parallel_walk(...)` instead
+- Keep the `path_format` / display construction (still needed for output formatting)
+- Keep the stdin handling block
+
+### Step 5: Add `BufferedWriter::take` method
+
+`writer.rs` needs a new method to extract the buffered lines:
+
+```rust
+pub fn take(&self) -> Vec<String> {
+    let lines = self.lines.lock().unwrap();
+    lines.borrow_mut().take().unwrap_or_default()
+}
+```
+
+### Step 6: Remove old code, update module declarations
+
+- Delete `src/utils/walker.rs` and `src/utils/filters.rs`
+- Update `src/utils.rs`: remove `walker`, `filters`, add `parallel_walker`
+- Remove `futures` and `crossbeam` from `Cargo.toml`
+- Keep `patterns.rs` (still used by benchmark)
+
+### Step 7: Update tests
+
+- Migrate walker unit tests to CLI integration tests in `tests/cli.rs`
+- Add a test with nested subdirectories + `.git` + `.gitignore` (exercises parallel walk)
+- Existing CLI tests should pass unchanged
+
+## Key design decisions
+
+### Why collect-and-sort (not streaming)?
+
+For the no-match workload (the optimization target), there are zero results to buffer — memory cost is nil. For match-heavy workloads, memory is proportional to total output size, which is bounded by what would be printed anyway. A sequence-number priority queue is a future optimization if memory becomes a concern.
+
+### Why remove `futures::ThreadPool`?
+
+With `ignore`'s parallel walker, each file is already dispatched to a worker thread. The separate pool adds overhead with no benefit — parallelism is already at the file level.
+
+### Why keep `patterns.rs`?
+
+Still used by `benches/patterns.rs`. Can be removed in a separate cleanup.
+
+### Output ordering change
+
+Current: deterministic, depth-first sorted within each directory level separately. New: deterministic, globally sorted by full path. These produce identical output for flat trees and are actually more consistent for deep trees (global sort vs per-level sort).
+
+## Verification
+
+1. `cargo test` — all unit + integration tests pass
+2. `cargo build --release` then:
+   - `./target/release/tgrep foooxxxyyy ~/dd/dd-source/domains </dev/null` — completes, no hang
+   - `hyperfine` A/B vs baseline binary
+3. Correctness: `diff` output against baseline binary — should match (modulo ordering improvement for deep trees)
+4. Feature parity: test `-i`, `-v`, `-l`, `-L`, `-c`, `-A`/`-B`, `-e`, `-f`, `-t`, `--ignore-symlinks`

--- a/IMPL_PARALLEL_WALKER.md
+++ b/IMPL_PARALLEL_WALKER.md
@@ -4,9 +4,9 @@
 
 Benchmarks show tgrep at ~14s vs rg at ~9s on a large monorepo no-match workload. A/B testing confirmed the gap is entirely structural — the custom sequential recursive walker in `walker.rs` (362 lines) plus the hand-rolled .gitignore parser in `patterns.rs` (514 lines) cannot match the parallel traversal of the `ignore` crate (same crate rg uses). All Track 1 micro-optimizations have been exhausted.
 
-## Approach: parallel walk with collect-and-sort ordering
+## Approach: parallel walk with compatibility-preserving ordering
 
-Replace the recursive `Walker` with `ignore::WalkBuilder::build_parallel()`. The parallel walker dispatches files to worker threads. Each thread greps the file and buffers output. After the walk completes, results are sorted by path and flushed to stdout — preserving deterministic output.
+Replace the recursive `Walker` with `ignore::WalkBuilder::build_parallel()`. The parallel walker dispatches files to worker threads. Each thread greps the file and buffers output. Output remains deterministic, but ordering must be preserved by stable sequence numbers assigned at discovery time, not by a global post-hoc path sort.
 
 The `futures::executor::ThreadPool` is removed — `ignore`'s parallel walker already provides file-level parallelism, making the separate pool redundant.
 
@@ -16,8 +16,8 @@ The `futures::executor::ThreadPool` is removed — `ignore`'s parallel walker al
 |------|--------|
 | `Cargo.toml` | Add `ignore = "0.4"`, remove `futures`, `crossbeam` |
 | `src/utils.rs` | Remove `walker`, `filters`, add `parallel_walker` |
-| `src/utils/parallel_walker.rs` | **New** — parallel walk + collect-and-sort output |
-| `src/main.rs` | Rewire to use `ParallelWalker`, translate filters/ignore to `ignore` overrides |
+| `src/utils/parallel_walker.rs` | **New** — parallel walk + buffered ordered flush |
+| `src/main.rs` | Rewire to use `ParallelWalker`, translate filters/ignore carefully to `ignore` primitives |
 | `src/utils/walker.rs` | **Delete** |
 | `src/utils/filters.rs` | **Delete** |
 | `src/utils/grep.rs` | Extract `grep_file` from `Walker::grep` (open, mmap, binary check, dispatch) |
@@ -59,7 +59,7 @@ Core structure:
 
 ```rust
 struct FileResult {
-    path: PathBuf,
+    seq: u64,
     output: Vec<String>,
 }
 
@@ -68,8 +68,8 @@ pub fn parallel_walk(
     grep: Grep,
     matcher: Matcher,
     display: Arc<dyn Display>,
-    overrides: Override,        // replaces force_ignore + file_filters
-    follow_links: bool,        // replaces !ignore_symlinks
+    overrides: Override,
+    follow_links: bool,
     print_file_separator: bool,
 ) {
     let results: Arc<Mutex<Vec<FileResult>>> = Arc::new(Mutex::new(Vec::new()));
@@ -97,12 +97,13 @@ pub fn parallel_walk(
                     return WalkState::Continue;
                 }
                 let path = entry.into_path();
+                let seq = next_seq.fetch_add(1, Ordering::Relaxed);
                 let writer = Arc::new(BufferedWriter::new());
                 let file_display = display.with_writer(writer.clone());
                 grep_file(&grep, &path, &matcher, &file_display);
                 if writer.has_some() {
                     results.lock().unwrap().push(FileResult {
-                        path,
+                        seq,
                         output: writer.take(),
                     });
                 }
@@ -111,9 +112,9 @@ pub fn parallel_walk(
         });
     }
 
-    // Sort and flush
+    // Sort and flush in compatibility order
     let mut results = Arc::try_unwrap(results).unwrap().into_inner().unwrap();
-    results.sort_by(|a, b| a.path.cmp(&b.path));
+    results.sort_by_key(|result| result.seq);
     let writer = display.writer();
     for (i, result) in results.iter().enumerate() {
         if print_file_separator && i > 0 { display.file_separator(); }
@@ -124,7 +125,7 @@ pub fn parallel_walk(
 }
 ```
 
-### Step 3: Translate filter/ignore patterns to `ignore::overrides`
+### Step 3: Translate filter/ignore patterns to `ignore` primitives with parity checks
 
 In `main.rs`, build `Override` from existing CLI args:
 
@@ -145,16 +146,27 @@ let overrides = override_builder.build()?;
 
 `.git/` force-ignore is unnecessary — `ignore` crate handles it natively.
 
+However, this translation is not "mechanical" until parity is proven. The current code combines:
+
+- parent `.gitignore` discovery
+- per-root forced excludes
+- separate file-filter matching
+- explicit path handling
+
+So this step needs focused tests for `-e`, `-f`, `-t`, nested `.gitignore`, and multiple roots before the old code is deleted.
+
 ### Step 4: Update `main.rs` wiring
 
 Replace the `for path in paths` loop body:
 
-- Remove `Walker::find_ignore_patterns_in_parents` (handled by `WalkBuilder::parents(true)`)
+- Remove `Walker::find_ignore_patterns_in_parents` only after confirming `WalkBuilder::parents(true)` matches current repository-root behavior
 - Remove `Patterns::new` and `Filters::new` (replaced by overrides)
 - Remove `WalkerBuilder` construction
 - Call `parallel_walk(...)` instead
 - Keep the `path_format` / display construction (still needed for output formatting)
 - Keep the stdin handling block
+
+Symlink behavior is not a free replacement. The current walker also canonicalizes symlinks, detects loops, and avoids descending into already-covered parent trees. If `ignore` does not match that behavior directly, keep a thin compatibility layer instead of silently changing traversal semantics.
 
 ### Step 5: Add `BufferedWriter::take` method
 
@@ -182,9 +194,9 @@ pub fn take(&self) -> Vec<String> {
 
 ## Key design decisions
 
-### Why collect-and-sort (not streaming)?
+### Why buffered ordered flush (not global path-sort)?
 
-For the no-match workload (the optimization target), there are zero results to buffer — memory cost is nil. For match-heavy workloads, memory is proportional to total output size, which is bounded by what would be printed anyway. A sequence-number priority queue is a future optimization if memory becomes a concern.
+For the no-match workload (the optimization target), there are zero results to buffer, so memory cost is nil. For match-heavy workloads, memory is proportional to total output size, which is bounded by what would be printed anyway. A sequence-number priority queue is a future optimization if end-of-walk buffering becomes a concern.
 
 ### Why remove `futures::ThreadPool`?
 
@@ -194,9 +206,11 @@ With `ignore`'s parallel walker, each file is already dispatched to a worker thr
 
 Still used by `benches/patterns.rs`. Can be removed in a separate cleanup.
 
-### Output ordering change
+### Output ordering
 
-Current: deterministic, depth-first sorted within each directory level separately. New: deterministic, globally sorted by full path. These produce identical output for flat trees and are actually more consistent for deep trees (global sort vs per-level sort).
+Current: deterministic traversal-based ordering, including CLI root order.
+
+New: deterministic ordering must remain compatible with current behavior. A global full-path sort is simpler, but it is a behavior change and should not be treated as equivalent.
 
 ## Verification
 
@@ -204,5 +218,6 @@ Current: deterministic, depth-first sorted within each directory level separatel
 2. `cargo build --release` then:
    - `./target/release/tgrep foooxxxyyy ~/dd/dd-source/domains </dev/null` — completes, no hang
    - `hyperfine` A/B vs baseline binary
-3. Correctness: `diff` output against baseline binary — should match (modulo ordering improvement for deep trees)
+3. Correctness: `diff` output against baseline binary — should match exactly for representative trees, including nested dirs and multiple CLI roots
 4. Feature parity: test `-i`, `-v`, `-l`, `-L`, `-c`, `-A`/`-B`, `-e`, `-f`, `-t`, `--ignore-symlinks`
+5. Symlink parity: verify loop detection and ancestor-tree dedup behavior still match the current walker

--- a/src/utils/mapped.rs
+++ b/src/utils/mapped.rs
@@ -22,15 +22,18 @@ pub struct Mapped {
 }
 
 impl Mapped {
-    pub fn new(path: &Path, len: usize) -> anyhow::Result<Self> {
+    pub fn open(path: &Path) -> anyhow::Result<Option<Self>> {
         let file = fs::File::open(path)?;
-        let mmap = unsafe { MmapOptions::new().len(len).map(&file)? };
-        Ok(Mapped {
+        if file.metadata()?.len() == 0 {
+            return Ok(None);
+        }
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
+        Ok(Some(Mapped {
             mapped: Arc::new(MappedInner {
                 path: path.to_owned(),
                 mmap,
             }),
-        })
+        }))
     }
 }
 
@@ -158,7 +161,7 @@ mod tests {
     #[test]
     fn mapped_reader_returns_lines() {
         let file = TempFile::new(b"alpha\nbeta\ngamma");
-        let mapped = Mapped::new(file.path(), 16).unwrap();
+        let mapped = Mapped::open(file.path()).unwrap().unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -170,7 +173,7 @@ mod tests {
     #[test]
     fn mapped_reader_trims_cr_before_lf() {
         let file = TempFile::new(b"alpha\r\nbeta\r\n");
-        let mapped = Mapped::new(file.path(), 13).unwrap();
+        let mapped = Mapped::open(file.path()).unwrap().unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("alpha"), lines.next());
@@ -181,7 +184,7 @@ mod tests {
     #[test]
     fn mapped_reader_falls_back_for_invalid_utf8() {
         let file = TempFile::new(b"ok\nf\x80o\n");
-        let mapped = Mapped::new(file.path(), 7).unwrap();
+        let mapped = Mapped::open(file.path()).unwrap().unwrap();
         let mut lines = mapped.lines().unwrap();
 
         assert_eq!(Some("ok"), lines.next());

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -139,13 +139,18 @@ impl Walker {
     }
 
     fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
-        let walker = {
-            let mut walker = self.clone();
-            if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
-                ignore_patterns.extend(&walker.ignore_patterns);
-                walker.ignore_patterns = Arc::new(ignore_patterns);
+        let owned_walker;
+        let walker = match Self::process_gitignore(path) {
+            Some(mut ignore_patterns) => {
+                owned_walker = {
+                    let mut w = self.clone();
+                    ignore_patterns.extend(&w.ignore_patterns);
+                    w.ignore_patterns = Arc::new(ignore_patterns);
+                    w
+                };
+                &owned_walker
             }
-            walker
+            None => self,
         };
 
         let mut to_dive = Vec::new();

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -189,22 +189,18 @@ impl Walker {
     }
 
     fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
-        let len = fs::metadata(entry.as_path())
-            .ok()
-            .map(|meta| meta.len() as usize);
-        if matches!(len, Some(0)) {
-            (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
-            return;
-        }
-        match len.and_then(|len| Mapped::new(&entry, len).ok()) {
-            Some(mapped) => {
+        match Mapped::open(&entry) {
+            Ok(Some(mapped)) => {
                 if content_inspector::inspect(&mapped).is_binary() {
                     debug!("Skipping binary file '{}'", entry.display());
                     return;
                 }
                 (grep)(Arc::new(mapped), matcher, display);
             }
-            None => {
+            Ok(None) => {
+                (grep)(Arc::new(Zero::new((*entry).clone())), matcher, display);
+            }
+            Err(_) => {
                 warn!("Failed to map file '{}'", entry.display());
                 (grep)(entry, matcher, display);
             }


### PR DESCRIPTION
## Summary
This draft PR captures the architecture-level conclusion from the optimization experiments.

It adds:
- `ARCHITECTURE_SEARCH_REDESIGN.md`
- a follow-up note from the failed classify-layer prototype that a mostly-text repository weakens prefix-only classification as a standalone optimization unless it replaces enough downstream work

## What this branch is for
This is not another micro-optimization branch. It records the redesign direction after the experiment branches showed diminishing returns from local tuning.

## Main conclusion
The next credible path to a materially faster `tgrep` is structural:
- replace or redesign the walk/ignore layer
- introduce a real classify layer on top of the stronger combined file path
- split literal and regex search engines
- decouple output ordering from execution

## Notes
This PR is intended as a reference checkpoint so the investigation can restart later from a clear architectural plan.