### PR TITLE
Bump version to 1.6.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep"
-version = "1.6.10"
+version = "1.6.11"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrep"
-version = "1.6.10"
+version = "1.6.11"
 authors = ["Dmytro Milinevskyi <dmilinevskyi@gmail.com>"]
 description = "Toy grep that honors .gitignore"
 license = "Unlicense"


### PR DESCRIPTION
## Summary

- bump `tgrep` version to `1.6.11`
- update `Cargo.lock` to match the release version

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo publish --dry-run`
- `cargo publish`
