### PR TITLE
Release 1.6.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep"
-version = "1.6.11"
+version = "1.6.12"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrep"
-version = "1.6.11"
+version = "1.6.12"
 authors = ["Dmytro Milinevskyi <dmilinevskyi@gmail.com>"]
 description = "Toy grep that honors .gitignore"
 license = "Unlicense"


### PR DESCRIPTION
## Summary

- bump crate version to 1.6.12
- include the recent performance improvements in the release cut
- align the repository state with the published crate and GitHub tag

## Validation

- cargo test
- cargo package
- cargo publish
