### PR TITLE
Improve grep perf planning, benchmarks, and ordered emission

### DIFF
--- a/benches/patterns.rs
+++ b/benches/patterns.rs
@@ -1,18 +1,270 @@
+use std::fs;
 use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use regex::Regex;
 
+use tgrep::utils::display::{Display, DisplayTerminal, Format, PathFormat};
+use tgrep::utils::filters::Filters;
+use tgrep::utils::grep::{self, Grep};
+use tgrep::utils::lines::Zero;
+use tgrep::utils::mapped::Mapped;
+use tgrep::utils::matcher::{Match, Matcher, MatcherOptions};
 use tgrep::utils::patterns::Patterns;
+use tgrep::utils::walker::WalkerBuilder;
+use tgrep::utils::writer::Writer;
 
-fn double_star(c: &mut Criterion) {
-    let _ = env_logger::builder().try_init();
+fn unique_path(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    path.push(format!("{}-{}", prefix, unique));
+    path
+}
+
+struct TempTree {
+    path: PathBuf,
+}
+
+impl TempTree {
+    fn new(prefix: &str) -> Self {
+        let path = unique_path(prefix);
+        fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.path.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn collect_files(&self) -> Vec<PathBuf> {
+        fn walk(path: &Path, files: &mut Vec<PathBuf>) {
+            let entries = fs::read_dir(path).unwrap();
+            for entry in entries {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                let file_type = entry.file_type().unwrap();
+                if file_type.is_dir() {
+                    walk(&path, files);
+                } else if file_type.is_file() {
+                    files.push(path);
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        walk(&self.path, &mut files);
+        files.sort();
+        files
+    }
+}
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+#[derive(Clone, Default)]
+struct NullWriter;
+
+impl Writer for NullWriter {
+    fn write(&self, _content: &str) {}
+}
+
+fn build_matcher(needle: &str) -> Matcher {
+    let regexp = Regex::new(needle).unwrap();
+    Arc::new(Box::new(move |line: &str, options| -> Option<Vec<Match>> {
+        match options {
+            MatcherOptions::Fuzzy => regexp
+                .shortest_match(line)
+                .map(|pos| vec![Match::new(0, pos)]),
+            MatcherOptions::Exact(max) => {
+                let mut matches = Vec::new();
+                for (idx, hit) in regexp.find_iter(line).enumerate() {
+                    matches.push(Match::new(hit.start(), hit.end()));
+                    if idx + 1 == max {
+                        break;
+                    }
+                }
+                if matches.is_empty() {
+                    None
+                } else {
+                    Some(matches)
+                }
+            }
+        }
+    }))
+}
+
+fn build_display(root: &Path) -> Arc<dyn Display> {
+    let root = root.to_path_buf();
+    let path_format: PathFormat = Arc::new(Box::new(move |path: &Path| {
+        path.strip_prefix(&root)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }));
+    Arc::new(DisplayTerminal::new(
+        usize::MAX,
+        Format::Rich {
+            colour: false,
+            match_only: false,
+            no_path: false,
+            no_lno: false,
+        },
+        path_format,
+        Arc::new(NullWriter),
+    ))
+}
+
+fn run_grep_on_files(files: &[PathBuf], matcher: Matcher, display: Arc<dyn Display>, grep: Grep) {
+    for path in files {
+        if let Some(mapped) = Mapped::open(path).unwrap() {
+            if content_inspector::inspect(&mapped).is_binary() {
+                continue;
+            }
+            grep(Arc::new(mapped), matcher.clone(), display.clone());
+        } else {
+            grep(
+                Arc::new(Zero::new(path.to_path_buf())),
+                matcher.clone(),
+                display.clone(),
+            );
+        }
+    }
+}
+
+fn bench_tree_sparse() -> TempTree {
+    let tree = TempTree::new("tgrep-bench-sparse");
+    tree.write(".gitignore", "ignored/\n");
+    for dir_idx in 0..12 {
+        for file_idx in 0..40 {
+            let name = format!("dir-{dir_idx:02}/file-{file_idx:03}.txt");
+            if file_idx % 17 == 0 {
+                tree.write(&name, "alpha\nbeta\nneedle\ngamma\n");
+            } else {
+                tree.write(&name, "alpha\nbeta\ngamma\ndelta\n");
+            }
+        }
+    }
+    for file_idx in 0..80 {
+        let name = format!("ignored/file-{file_idx:03}.txt");
+        tree.write(&name, "needle\n");
+    }
+    tree
+}
+
+fn bench_tree_dense() -> TempTree {
+    let tree = TempTree::new("tgrep-bench-dense");
+    for dir_idx in 0..8 {
+        for file_idx in 0..24 {
+            let name = format!("dense-{dir_idx:02}/file-{file_idx:03}.txt");
+            let mut body = String::new();
+            for line_idx in 0..200 {
+                let line = if line_idx % 3 == 0 {
+                    "needle needle needle"
+                } else {
+                    "some ordinary text"
+                };
+                body.push_str(line);
+                body.push('\n');
+            }
+            tree.write(&name, &body);
+        }
+    }
+    tree
+}
+
+fn patterns_bench(c: &mut Criterion) {
+    let _ = env_logger::builder().is_test(true).try_init();
     let patterns = Patterns::new("/", &["foo/bar/**/qux/xyz".to_string()]);
-    c.bench_function("patters", |b| {
+    c.bench_function("patterns_double_star_match", |b| {
         b.iter(|| {
             patterns.is_excluded(black_box("foo/bar/zoo/too/qux/xyz"), false);
         })
     });
 }
 
-criterion_group!(benches, double_star);
+fn traversal_bench(c: &mut Criterion) {
+    let tree = bench_tree_sparse();
+    let matcher = build_matcher("needle");
+    let display = build_display(tree.path());
+    let grep: Grep = Arc::new(Box::new(|_, _, _| {}));
+    let file_filters = Filters::new(&["*.unlikely".to_string()]).unwrap();
+    let ignore_patterns = Patterns::new(tree.path().to_str().unwrap(), &[]);
+    let force_ignore_patterns = Patterns::new(tree.path().to_str().unwrap(), &[]);
+
+    c.bench_function("walk_ignore_and_filter_only", |b| {
+        b.iter(|| {
+            let walker = WalkerBuilder::new(grep.clone(), matcher.clone(), display.clone())
+                .ignore_patterns(ignore_patterns.clone())
+                .force_ignore_patterns(force_ignore_patterns.clone())
+                .file_filters(file_filters.clone())
+                .build();
+            walker.walk(black_box(tree.path()));
+        })
+    });
+}
+
+fn search_bench(c: &mut Criterion) {
+    let tree = bench_tree_sparse();
+    let files = tree.collect_files();
+    let matcher = build_matcher("needle");
+    let display = build_display(tree.path());
+    let grep = grep::grep();
+
+    c.bench_function("search_sorted_sparse_file_list", |b| {
+        b.iter(|| {
+            run_grep_on_files(
+                black_box(&files),
+                matcher.clone(),
+                display.clone(),
+                grep.clone(),
+            );
+        })
+    });
+}
+
+fn end_to_end_bench(c: &mut Criterion) {
+    let tree = bench_tree_dense();
+    let matcher = build_matcher("needle");
+    let display = build_display(tree.path());
+    let grep = grep::grep();
+    let file_filters = Filters::new(&["*".to_string()]).unwrap();
+    let ignore_patterns = Patterns::new(tree.path().to_str().unwrap(), &[]);
+    let force_ignore_patterns = Patterns::new(tree.path().to_str().unwrap(), &[]);
+
+    c.bench_function("walk_and_search_dense_tree", |b| {
+        b.iter(|| {
+            let walker = WalkerBuilder::new(grep.clone(), matcher.clone(), display.clone())
+                .ignore_patterns(ignore_patterns.clone())
+                .force_ignore_patterns(force_ignore_patterns.clone())
+                .file_filters(file_filters.clone())
+                .build();
+            walker.walk(black_box(tree.path()));
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    patterns_bench,
+    traversal_bench,
+    search_bench,
+    end_to_end_bench
+);
 criterion_main!(benches);

--- a/docs/adr/0001-grep-performance-plan.md
+++ b/docs/adr/0001-grep-performance-plan.md
@@ -1,0 +1,146 @@
+# ADR 0001: Grep Performance Plan and Benchmarking Prerequisites
+
+## Status
+
+Accepted
+
+## Context
+
+`tgrep` needs a performance-oriented architecture change with one non-negotiable functional requirement:
+
+- output must be sorted lexicographically by file path
+
+A second requirement is desirable but subordinate to sorting:
+
+- emit output as soon as possible once matches are known, while still respecting lexicographic order
+
+The current implementation mixes traversal, search, buffering, and output coordination. That makes it difficult to reason about:
+
+- true output ordering guarantees
+- time to first emitted match
+- throughput under parallel search
+- whether a change is actually faster
+
+Before changing the architecture, the project needs an explicit target design and benchmark coverage that measures both throughput and latency.
+
+## Decision
+
+We will execute the work in three stages:
+
+1. Define the target architecture and measurement strategy in an ADR.
+2. Add benchmarks and deterministic benchmark corpora before changing the hot path.
+3. Refactor the search pipeline only after a measurable baseline exists.
+
+## Ordering Rule
+
+The new architecture must preserve this invariant:
+
+- files are emitted in global lexicographic order
+
+This means output order is determined by sorted file paths, not by traversal order and not by worker completion order.
+
+The implementation may search files out of order and in parallel, but the emitter must not print file `N` until all lexicographically earlier files are resolved.
+
+## Target Architecture
+
+The target design is a three-stage pipeline:
+
+1. Enumerator
+   - discovers candidate files
+   - applies ignore and file-filter rules
+   - produces a globally lexicographically sorted stream or list of files
+   - assigns each file a monotonic sequence number derived from sorted order
+
+2. Worker pool
+   - searches files in parallel
+   - returns either `NoMatch` or `Match` results keyed by sequence number
+   - is allowed to search ahead of the current output cursor
+
+3. Ordered emitter
+   - owns stdout
+   - tracks the next sequence number eligible for emission
+   - buffers out-of-order completed results until all earlier files are resolved
+   - emits the earliest ready file immediately
+
+This architecture replaces directory-local batching with a global coordination model.
+
+## Benchmark Prerequisites
+
+Before the refactor, the project needs deterministic benchmark inputs and benchmark coverage at three levels.
+
+### Deterministic corpora
+
+Benchmark corpora must be generated from a fixed seed or deterministic recipe so that results are comparable across revisions.
+
+The generated datasets should cover:
+
+- many tiny files with sparse matches
+- many tiny files with dense matches
+- medium files with regular matches
+- large files with rare matches
+- trees with `.gitignore` usage
+- cases where early lexicographic files are slow or negative and later files match quickly
+
+### Benchmark layers
+
+1. Traversal benchmarks
+   - measure file discovery, filtering, and ignore processing
+   - exclude regex search cost where possible
+
+2. Search benchmarks
+   - measure grep over a precomputed sorted file list
+   - isolate search and result assembly from tree walking
+
+3. End-to-end CLI benchmarks
+   - measure the real binary on generated corpora
+   - capture both total runtime and first-output latency
+
+## Metrics
+
+The benchmark suite must report or make it easy to derive:
+
+- total wall-clock runtime
+- time to first stdout byte
+- time to first emitted match
+- total files searched
+- total matches emitted
+- throughput in files per second or bytes per second where useful
+
+For the ordered emitter design, latency metrics are first-class. A change that improves total runtime but worsens first emitted match latency is not automatically an improvement.
+
+## Initial Implementation Plan
+
+The work will proceed in the following order:
+
+1. Add benchmark corpus generation helpers.
+2. Add Criterion benchmarks for traversal-oriented and search-oriented measurements.
+3. Add at least one process-level benchmark harness for first-output and first-match latency.
+4. Record a baseline on the current implementation.
+5. Refactor the architecture toward a global sorted enumerator, parallel workers, and a single ordered emitter.
+6. Compare the refactor against the baseline before iterating further.
+
+## Alternatives Considered
+
+### Refactor first, benchmark later
+
+Rejected because the redesign is specifically about performance and latency tradeoffs. Without a baseline, it is too easy to optimize the wrong stage.
+
+### Preserve current traversal order as output order
+
+Rejected because the required functional invariant is lexicographic file ordering.
+
+### Optimize only the regex hot path
+
+Rejected as a first step because current behavior indicates that traversal, buffering, and output coordination are also on the critical path.
+
+## Consequences
+
+This decision adds benchmark infrastructure before user-visible architecture changes.
+
+That increases short-term work, but it reduces the risk of:
+
+- shipping a refactor that regresses latency
+- optimizing traversal while output buffering remains the bottleneck
+- debating architecture changes without numbers
+
+The refactor that follows this ADR should be evaluated against benchmark evidence, not only code inspection.

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ fn main() -> Result<(), Error> {
     let paths = {
         let mut paths = paths.clone();
         paths.extend(args.opt_paths);
+        paths.sort();
         paths
     };
     info!(

--- a/src/utils/walker.rs
+++ b/src/utils/walker.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 
+use crossbeam::channel;
 use crossbeam::sync::WaitGroup;
 use futures::executor::ThreadPool;
 use log::{debug, error, info, warn};
@@ -36,6 +37,11 @@ pub struct Walker {
     display: Arc<dyn Display>,
     print_file_separator: bool,
     file_separator_printed: Rc<AtomicBool>,
+}
+
+struct GrepResult {
+    seq: usize,
+    writer: Arc<BufferedWriter>,
 }
 
 pub struct WalkerBuilder(Walker);
@@ -138,7 +144,7 @@ impl Walker {
         path.exists()
     }
 
-    fn walk_dir(&self, path: &Path, parents: &[PathBuf]) {
+    fn collect_files_in_dir(&self, path: &Path, parents: &[PathBuf], files: &mut Vec<PathBuf>) {
         let walker = {
             let mut walker = self.clone();
             if let Some(mut ignore_patterns) = Self::process_gitignore(path) {
@@ -189,10 +195,10 @@ impl Walker {
             parents
         };
         for (entry, file_type) in to_dive {
-            walker.walk_with_parents(&entry, Some(file_type), &parents);
+            walker.collect_files_with_parents(&entry, Some(file_type), &parents, files);
         }
 
-        self.grep_many(&to_grep);
+        files.extend(to_grep);
     }
 
     fn grep(grep: Grep, entry: Arc<PathBuf>, matcher: Matcher, display: Arc<dyn Display>) {
@@ -214,42 +220,64 @@ impl Walker {
         }
     }
 
+    fn flush_writer(
+        &self,
+        writer: &Arc<BufferedWriter>,
+        output: &Arc<dyn crate::utils::writer::Writer>,
+    ) {
+        if self.print_file_separator
+            && writer.has_some()
+            && self.file_separator_printed.swap(true, Ordering::Relaxed)
+        {
+            self.display.file_separator();
+        }
+        writer.flush(output);
+    }
+
     fn grep_many(&self, entries: &[PathBuf]) {
-        let writer = self.display.writer();
-        let mut writers = Vec::with_capacity(entries.len());
+        let output = self.display.writer();
+        if entries.len() < 3 || self.tpool.is_none() {
+            for entry in entries {
+                let entry = Arc::new(entry.clone());
+                let matcher = self.matcher.clone();
+                let writer = Arc::new(BufferedWriter::new());
+                let display = self.display.with_writer(writer.clone());
+                Walker::grep(self.grep.clone(), entry, matcher, display);
+                self.flush_writer(&writer, &output);
+            }
+            return;
+        }
+
+        let (tx, rx) = channel::unbounded();
+        let mut pending = std::collections::BTreeMap::new();
         let wg = WaitGroup::new();
-        for entry in entries {
+        let tpool = self.tpool.as_ref().unwrap();
+
+        for (seq, entry) in entries.iter().enumerate() {
             let entry = Arc::new(entry.clone());
             let matcher = self.matcher.clone();
             let writer = Arc::new(BufferedWriter::new());
             let display = self.display.with_writer(writer.clone());
-            writers.push(writer);
-            if entries.len() < 3 {
-                Walker::grep(self.grep.clone(), entry, matcher, display);
-                continue;
-            }
-            match &self.tpool {
-                Some(tpool) => {
-                    let grep = self.grep.clone();
-                    let wg = wg.clone();
-                    tpool.spawn_ok(async move {
-                        Walker::grep(grep, entry, matcher, display);
-                        drop(wg);
-                    });
-                }
-                None => Walker::grep(self.grep.clone(), entry, matcher, display),
+            let grep = self.grep.clone();
+            let tx = tx.clone();
+            let wg = wg.clone();
+            tpool.spawn_ok(async move {
+                Walker::grep(grep, entry, matcher, display);
+                tx.send(GrepResult { seq, writer }).ok();
+                drop(wg);
+            });
+        }
+        drop(tx);
+
+        let mut next = 0;
+        for result in rx {
+            pending.insert(result.seq, result.writer);
+            while let Some(writer) = pending.remove(&next) {
+                self.flush_writer(&writer, &output);
+                next += 1;
             }
         }
         wg.wait();
-        for w in writers {
-            if self.print_file_separator
-                && w.has_some()
-                && self.file_separator_printed.swap(true, Ordering::Relaxed)
-            {
-                self.display.file_separator();
-            }
-            w.flush(&writer);
-        }
     }
 
     fn canonicalize(&self, orig: &Path, resolved: &Path) -> anyhow::Result<PathBuf> {
@@ -265,7 +293,13 @@ impl Walker {
         path
     }
 
-    fn process_symlink(&self, orig: &Path, resolved: &Path, parents: &[PathBuf]) {
+    fn collect_symlink_files(
+        &self,
+        orig: &Path,
+        resolved: &Path,
+        parents: &[PathBuf],
+        files: &mut Vec<PathBuf>,
+    ) {
         let path = self.canonicalize(orig, resolved);
         if let Err(e) = path {
             error!("Failed to canonicalize '{}': {}", resolved.display(), e);
@@ -291,14 +325,20 @@ impl Walker {
             );
             return;
         }
-        self.walk_with_parents(&path, None, &{
+        self.collect_files_with_parents(&path, None, &{
             let mut parents = parents.to_owned();
             parents.push(path.clone());
             parents
-        });
+        }, files);
     }
 
-    fn walk_with_parents(&self, path: &Path, file_type: Option<fs::FileType>, parents: &[PathBuf]) {
+    fn collect_files_with_parents(
+        &self,
+        path: &Path,
+        file_type: Option<fs::FileType>,
+        parents: &[PathBuf],
+        files: &mut Vec<PathBuf>,
+    ) {
         let file_type = file_type.or_else(|| match fs::symlink_metadata(path) {
             Ok(meta) => Some(meta.file_type()),
             Err(e) => {
@@ -311,21 +351,16 @@ impl Walker {
             _ => return,
         };
         if file_type.is_dir() {
-            self.walk_dir(path, parents);
+            self.collect_files_in_dir(path, parents, files);
         } else if file_type.is_file() {
-            Walker::grep(
-                self.grep.clone(),
-                Arc::new(path.to_path_buf()),
-                self.matcher.clone(),
-                self.display.clone(),
-            );
+            files.push(path.to_path_buf());
         } else if file_type.is_symlink() {
             if self.ignore_symlinks {
                 info!("Skipping symlink '{}'", path.display());
                 return;
             }
             match fs::read_link(path) {
-                Ok(resolved) => self.process_symlink(path, &resolved, parents),
+                Ok(resolved) => self.collect_symlink_files(path, &resolved, parents, files),
                 Err(e) => error!("Failed to read link '{}': {}", path.display(), e),
             }
         } else {
@@ -359,7 +394,10 @@ impl Walker {
     }
 
     pub fn walk(&self, path: &Path) {
-        self.walk_with_parents(path, None, &[]);
+        let mut files = Vec::new();
+        self.collect_files_with_parents(path, None, &[], &mut files);
+        files.sort();
+        self.grep_many(&files);
     }
 }
 
@@ -529,6 +567,27 @@ mod tests {
         walker.walk(temp.path());
 
         assert_eq!(vec!["visible.rs"], writer.lines());
+    }
+
+    #[test]
+    fn walk_outputs_files_in_global_lexicographic_order() {
+        let temp = TempDir::new();
+        temp.write("a.txt", b"match\n");
+        temp.write("b/c.txt", b"match\n");
+
+        let writer = TestWriter::new();
+        let walker = WalkerBuilder::new(
+            grep_recorder(),
+            matcher(),
+            display(Arc::new(writer.clone())),
+        )
+        .thread_pool(ThreadPool::new().unwrap())
+        .file_filters(Filters::new(&["*".to_string()]).unwrap())
+        .build();
+
+        walker.walk(temp.path());
+
+        assert_eq!(vec!["a.txt", "c.txt"], writer.lines());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an ADR for the grep performance plan and benchmark prerequisites
- add deterministic Criterion benches for pattern matching, traversal, sparse search, and end-to-end walk plus search
- refactor the walker to collect files globally, sort them lexicographically, and emit results in ordered sequence while still searching files in parallel

## Benchmarks

Criterion comparison between the benchmark baseline commit `c067e96` and the refactor commit `c79f61b`:

- `patterns_double_star_match`: 15.389 ns -> 15.671 ns
- `walk_ignore_and_filter_only`: 917.15 us -> 940.71 us
- `search_sorted_sparse_file_list`: 9.1030 ms -> 9.4201 ms
- `walk_and_search_dense_tree`: 15.078 ms -> 14.999 ms

External `hyperfine` run on `/System/Library` from the current branch release binary:

- PATH `tgrep`: 18.273 s
- local `./target/release/tgrep`: 12.939 s

## Testing

- `cargo test`
- `cargo bench --no-run`
- `cargo bench --bench patterns -- --noplot`
