### PR TITLE
Add auto-approve workflow for owner PRs

### DIFF
--- a/.github/workflows/auto-approve-owner-prs.yml
+++ b/.github/workflows/auto-approve-owner-prs.yml
@@ -1,0 +1,23 @@
+name: Auto-approve owner PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == github.repository_owner && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow to auto-approve PRs opened by the repository owner
- use `pull_request_target` with minimal permissions and skip draft PRs

## Testing

- not run (workflow YAML change only)
