### PR TITLE
Bump crate version to 1.6.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep"
-version = "1.6.13"
+version = "1.6.14"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep"
-version = "1.6.14"
+version = "1.6.15"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrep"
-version = "1.6.14"
+version = "1.6.15"
 authors = ["Dmytro Milinevskyi <dmilinevskyi@gmail.com>"]
 description = "Toy grep that honors .gitignore"
 license = "Unlicense"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrep"
-version = "1.6.13"
+version = "1.6.14"
 authors = ["Dmytro Milinevskyi <dmilinevskyi@gmail.com>"]
 description = "Toy grep that honors .gitignore"
 license = "Unlicense"


### PR DESCRIPTION
## Summary
- bump crate version to 1.6.15
- publish `tgrep` 1.6.15 to crates.io

## Testing
- `cargo test`

## Notes
- `tgrep` 1.6.14 was already present on crates.io, so the release was finalized as 1.6.15
